### PR TITLE
Changing the master and slave language

### DIFF
--- a/PythonFiles/Driver/instrumentDrivers.py
+++ b/PythonFiles/Driver/instrumentDrivers.py
@@ -149,7 +149,7 @@ class pmHP8163:
         return float(self.inst.ask(cmd))
 
     def triggerReadPower(self):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.inst.write( ':INIT%d:CHAN1:TRIG:IMM' % self.slot)
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.slot, self.head)

--- a/PythonFiles/Driver/minimalmodbus.py
+++ b/PythonFiles/Driver/minimalmodbus.py
@@ -68,15 +68,15 @@ CLOSE_PORT_AFTER_EACH_CALL = True
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU protocol (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU protocol (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``/com3`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
 
     """
 
-    def __init__(self, port, slaveaddress):
+    def __init__(self, port, subordinateaddress):
 
         self.serial = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, \
             stopbits=STOPBITS, timeout=TIMEOUT)
@@ -97,8 +97,8 @@ class Instrument():
                 - Defaults to :data:`TIMEOUT`.
         """
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.debug = False
         """Set this to :const:`True` to print the communication details. Defaults to :const:`False`."""
@@ -123,14 +123,14 @@ class Instrument():
 
 
     ########################################
-    ## Functions for talking to the slave ##
+    ## Functions for talking to the subordinate ##
     ########################################
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -145,10 +145,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -165,17 +165,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -190,7 +190,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -210,21 +210,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -248,17 +248,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -277,9 +277,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -287,8 +287,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -307,9 +307,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -320,12 +320,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -344,17 +344,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -371,13 +371,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -395,16 +395,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -424,12 +424,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -450,17 +450,17 @@ class Instrument():
 
 
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -497,9 +497,9 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value. Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value. Same functionality also
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -597,25 +597,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -637,37 +637,37 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
         ## Communicate ##
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode == 16:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -675,7 +675,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -703,15 +703,15 @@ class Instrument():
     ## Communication implementation details ##
     ##########################################
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -720,23 +720,23 @@ class Instrument():
 
         """
         _checkFunctioncode(functioncode, None )
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
-        message             = _embedPayload(self.address, functioncode, payloadToSlave)
+        message             = _embedPayload(self.address, functioncode, payloadToSubordinate)
         response            = self._communicate(message)
-        payloadFromSlave    = _extractPayload(response, self.address, functioncode)
+        payloadFromSubordinate    = _extractPayload(response, self.address, functioncode)
 
-        return payloadFromSlave
+        return payloadFromSubordinate
 
 
     def _communicate(self, message):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            message (str): The raw message that is to be sent to the slave.
+            message (str): The raw message that is to be sent to the subordinate.
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -766,10 +766,10 @@ class Instrument():
             Note that these strings can look pretty strange when printed, as values 0 to 31 (dec) are
             ASCII control signs. For example 'vertical tab' and 'line feed' are among those.
 
-            The **raw message** to the slave has the frame format: slaveaddress byte + functioncode byte +
+            The **raw message** to the subordinate has the frame format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes).
 
-            The **received message** should have the format: slaveaddress byte + functioncode byte +
+            The **received message** should have the format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes)
 
             For Python3, the information sent to and from pySerial should be of the type bytes.
@@ -811,41 +811,41 @@ class Instrument():
 # Payload handling #
 ####################
 
-def _embedPayload(slaveaddress, functioncode, payloaddata):
-    """Build a message from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, functioncode, payloaddata):
+    """Build a message from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) message string for sending to the slave (including CRC etc).
+        The built (raw) message string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
-    The resulting message has the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+    The resulting message has the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
 
-    The CRC is calculated from the string made up of slaveaddress byte + functioncode byte + payloaddata.
+    The CRC is calculated from the string made up of subordinateaddress byte + functioncode byte + payloaddata.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
     # Build message
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
     message = firstPart + _calculateCrcString(firstPart)
     return message
 
 
-def _extractPayload(response, slaveaddress, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * functioncode (int): Used here for error checking only.
 
     Returns:
@@ -854,7 +854,7 @@ def _extractPayload(response, slaveaddress, functioncode):
     Raises:
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
-    The received message should have the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+    The received message should have the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
 
     """
     BYTEPOSITION_FOR_SLAVEADDRESS          = 0  # Zero-based counting
@@ -865,7 +865,7 @@ def _extractPayload(response, slaveaddress, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
 
     # Check CRC
@@ -879,18 +879,18 @@ def _extractPayload(response, slaveaddress, functioncode):
             _twoByteStringToNum(calculatedCRC), calculatedCRC,
             response))
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord( response[BYTEPOSITION_FOR_SLAVEADDRESS] )
 
-    if responseaddress != slaveaddress:
-        raise ValueError( 'Wrong return slave address: {0} instead of {1}. The response is: {2!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError( 'Wrong return subordinate address: {0} instead of {1}. The response is: {2!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord( response[BYTEPOSITION_FOR_FUNCTIONCODE ] )
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {0!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {0!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {0} instead of {1}. The response is: {2!r}'.format( \
@@ -942,8 +942,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1036,7 +1036,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1068,7 +1068,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1098,11 +1098,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1143,7 +1143,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1182,14 +1182,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1211,13 +1211,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1281,7 +1281,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -1646,11 +1646,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -1659,7 +1659,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):

--- a/PythonFiles/GUI/CheckButtonGettingStatus.py
+++ b/PythonFiles/GUI/CheckButtonGettingStatus.py
@@ -14,11 +14,11 @@ import Tkinter
 root=Tk()
 
 class CheckB():
-    def __init__(self, master, text):
+    def __init__(self, main, text):
         self.var = IntVar()
         self.text=text
         c = Checkbutton(
-            master, text=text,
+            main, text=text,
             variable=self.var,
             command=self.check)
         c.pack()

--- a/PythonFiles/GUI/MainGui.py
+++ b/PythonFiles/GUI/MainGui.py
@@ -10,11 +10,11 @@ import Tkinter as Tk
 #esablish the size of the rootwindow
 
 class CheckButton():
-    def __init__(self, master, text):
+    def __init__(self, main, text):
         self.var = Tk.IntVar()
         self.text=text
         c = Tk.Checkbutton(
-            master, text=text,
+            main, text=text,
             variable=self.var,
             command=self.check)
         c.pack()
@@ -38,7 +38,7 @@ class MainGui(CheckB):
         self.root.title("RT GUI")   # add a title to the root window
         self.root.geometry("800x800")
         self.root.resizable(0,0)
-        self.frame = Tk.Frame(master = self.root,width=1000, height=1000, bg='blue')
+        self.frame = Tk.Frame(main = self.root,width=1000, height=1000, bg='blue')
         self.addCheckbutton()
         self.frame.pack()
  # this is where you put the dimension of the frame

--- a/PythonFiles/GUI/MainGui_rev1.py
+++ b/PythonFiles/GUI/MainGui_rev1.py
@@ -10,11 +10,11 @@ import Tkinter as Tk
 #esablish the size of the rootwindow
 
 class CheckButton():
-    def __init__(self, master, text):
+    def __init__(self, main, text):
         self.var = Tk.IntVar()
         self.text=text
         c = Tk.Checkbutton(
-            master, text=text,
+            main, text=text,
             variable=self.var,
             command=self.check)
         #c.pack()
@@ -42,7 +42,7 @@ class MainGui:
         self.root.grid_columnconfigure(0, weight = 
         
         #create the containers or frames color blue
-        self.frame = Tk.Frame(master = self.root,bg = 'blue', width=100, height=100,\
+        self.frame = Tk.Frame(main = self.root,bg = 'blue', width=100, height=100,\
                               pady = 1)
        
         #assign a location for this frame

--- a/PythonFiles/GUI/MainGui_rev2.py
+++ b/PythonFiles/GUI/MainGui_rev2.py
@@ -10,11 +10,11 @@ import Tkinter as Tk
 #esablish the size of the rootwindow
 
 class CheckButton():
-    def __init__(self, master, text, row = None):
+    def __init__(self, main, text, row = None):
         self.var = Tk.IntVar()
         self.text=text
         c = Tk.Checkbutton(
-            master, activebackground = "red",\
+            main, activebackground = "red",\
             activeforeground = "yellow",\
             bg = "blue",\
             bitmap = None,\
@@ -50,7 +50,7 @@ class MainGui:
  
  
         #create the containers or frames color blue
-        self.frame = Tk.Frame(master = self.root,bg = 'blue', width=500, height=500,\
+        self.frame = Tk.Frame(main = self.root,bg = 'blue', width=500, height=500,\
                               pady = 1)
         self.label = Tk.Label(self.frame,text ="NANO RT")
         self.label.grid(row = 0, sticky = 'n')

--- a/PythonFiles/GUI/MainGui_rev3.py
+++ b/PythonFiles/GUI/MainGui_rev3.py
@@ -10,11 +10,11 @@ import Tkinter as Tk
 #esablish the size of the rootwindow
 
 class CheckButton():
-    def __init__(self, master, text, row = None):
+    def __init__(self, main, text, row = None):
         self.var = Tk.IntVar()
         self.text=text
         c = Tk.Checkbutton(
-            master, activebackground = "red",\
+            main, activebackground = "red",\
             activeforeground = "yellow",\
             bg = "blue",\
             bitmap = None,\
@@ -51,7 +51,7 @@ class MainGui:
  
  
         #create the containers or frames color blue
-        self.frame = Tk.Frame(master = self.root,bg = 'blue', width=500, height=500,\
+        self.frame = Tk.Frame(main = self.root,bg = 'blue', width=500, height=500,\
                               pady = 1)
         self.label = Tk.Label(self.frame,text ="NANO RT")
         self.label.grid(row = 0, sticky = 'n')

--- a/PythonFiles/PyVISA_/docs/conf.py
+++ b/PythonFiles/PyVISA_/docs/conf.py
@@ -38,8 +38,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'PyVISA'

--- a/PythonFiles/TestScripts/Chan_Pwr_Tune_Test/InstrumentDrivers_DS.py
+++ b/PythonFiles/TestScripts/Chan_Pwr_Tune_Test/InstrumentDrivers_DS.py
@@ -819,7 +819,7 @@ class Agilent8163B(Base):
 
 
     def getDisplayedPower(self, queryDelay = 0.002):
-        #getPower() will not work for the slave module, so we need to read the display with FETCH
+        #getPower() will not work for the subordinate module, so we need to read the display with FETCH
         cmd = 'FETC%d:CHAN%d:POW?'%(self._conf[self._ActiveConf][0],self._conf[self._ActiveConf][1])
         reply = self.query(cmd, delay=queryDelay)
         try:
@@ -877,7 +877,7 @@ class Agilent8163B(Base):
 
     #<DS>
     def triggerReadPower(self, fltQueryDelay = 0.05):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.write( ':INIT%d:CHAN1:TRIG:IMM' % self.getSlot())
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.getSlot(),self.getHead())

--- a/PythonFiles/TestScripts/Gencfg_PwrSupply/InstrumentDrivers_DS.py
+++ b/PythonFiles/TestScripts/Gencfg_PwrSupply/InstrumentDrivers_DS.py
@@ -819,7 +819,7 @@ class Agilent8163B(Base):
 
 
     def getDisplayedPower(self, queryDelay = 0.002):
-        #getPower() will not work for the slave module, so we need to read the display with FETCH
+        #getPower() will not work for the subordinate module, so we need to read the display with FETCH
         cmd = 'FETC%d:CHAN%d:POW?'%(self._conf[self._ActiveConf][0],self._conf[self._ActiveConf][1])
         reply = self.query(cmd, delay=queryDelay)
         try:
@@ -877,7 +877,7 @@ class Agilent8163B(Base):
 
     #<DS>
     def triggerReadPower(self, fltQueryDelay = 0.05):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.write( ':INIT%d:CHAN1:TRIG:IMM' % self.getSlot())
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.getSlot(),self.getHead())

--- a/PythonFiles/TestScripts/Gencfg_PwrSupply_Test/InstrumentDrivers_DS.py
+++ b/PythonFiles/TestScripts/Gencfg_PwrSupply_Test/InstrumentDrivers_DS.py
@@ -819,7 +819,7 @@ class Agilent8163B(Base):
 
 
     def getDisplayedPower(self, queryDelay = 0.002):
-        #getPower() will not work for the slave module, so we need to read the display with FETCH
+        #getPower() will not work for the subordinate module, so we need to read the display with FETCH
         cmd = 'FETC%d:CHAN%d:POW?'%(self._conf[self._ActiveConf][0],self._conf[self._ActiveConf][1])
         reply = self.query(cmd, delay=queryDelay)
         try:
@@ -877,7 +877,7 @@ class Agilent8163B(Base):
 
     #<DS>
     def triggerReadPower(self, fltQueryDelay = 0.05):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.write( ':INIT%d:CHAN1:TRIG:IMM' % self.getSlot())
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.getSlot(),self.getHead())

--- a/PythonFiles/aa_gpio/aardvark_py.py
+++ b/PythonFiles/aa_gpio/aardvark_py.py
@@ -544,9 +544,9 @@ AA_I2C_NO_STOP           = 0x04
 AA_I2C_SIZED_READ        = 0x10
 AA_I2C_SIZED_READ_EXTRA1 = 0x20
 
-# Read a stream of bytes from the I2C slave device.
-def aa_i2c_read (aardvark, slave_addr, flags, data_in):
-    """usage: (int return, u08[] data_in) = aa_i2c_read(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_in)
+# Read a stream of bytes from the I2C subordinate device.
+def aa_i2c_read (aardvark, subordinate_addr, flags, data_in):
+    """usage: (int return, u08[] data_in) = aa_i2c_read(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -572,7 +572,7 @@ def aa_i2c_read (aardvark, slave_addr, flags, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_) = api.py_aa_i2c_read(aardvark, slave_addr, flags, num_bytes, data_in)
+    (_ret_) = api.py_aa_i2c_read(aardvark, subordinate_addr, flags, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(_ret_, len(data_in))):]
     return (_ret_, data_in)
@@ -588,12 +588,12 @@ AA_I2C_STATUS_ARB_LOST      = 5
 AA_I2C_STATUS_BUS_LOCKED    = 6
 AA_I2C_STATUS_LAST_DATA_ACK = 7
 
-# Read a stream of bytes from the I2C slave device.
+# Read a stream of bytes from the I2C subordinate device.
 # This API function returns the number of bytes read into
 # the num_read variable.  The return value of the function
 # is a status code.
-def aa_i2c_read_ext (aardvark, slave_addr, flags, data_in):
-    """usage: (int return, u08[] data_in, u16 num_read) = aa_i2c_read_ext(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_in)
+def aa_i2c_read_ext (aardvark, subordinate_addr, flags, data_in):
+    """usage: (int return, u08[] data_in, u16 num_read) = aa_i2c_read_ext(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -619,15 +619,15 @@ def aa_i2c_read_ext (aardvark, slave_addr, flags, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_, num_read) = api.py_aa_i2c_read_ext(aardvark, slave_addr, flags, num_bytes, data_in)
+    (_ret_, num_read) = api.py_aa_i2c_read_ext(aardvark, subordinate_addr, flags, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(num_read, len(data_in))):]
     return (_ret_, data_in, num_read)
 
 
-# Write a stream of bytes to the I2C slave device.
-def aa_i2c_write (aardvark, slave_addr, flags, data_out):
-    """usage: int return = aa_i2c_write(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_out)
+# Write a stream of bytes to the I2C subordinate device.
+def aa_i2c_write (aardvark, subordinate_addr, flags, data_out):
+    """usage: int return = aa_i2c_write(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -643,15 +643,15 @@ def aa_i2c_write (aardvark, slave_addr, flags, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_i2c_write(aardvark, slave_addr, flags, num_bytes, data_out)
+    return api.py_aa_i2c_write(aardvark, subordinate_addr, flags, num_bytes, data_out)
 
 
-# Write a stream of bytes to the I2C slave device.
+# Write a stream of bytes to the I2C subordinate device.
 # This API function returns the number of bytes written into
 # the num_written variable.  The return value of the function
 # is a status code.
-def aa_i2c_write_ext (aardvark, slave_addr, flags, data_out):
-    """usage: (int return, u16 num_written) = aa_i2c_write_ext(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_out)
+def aa_i2c_write_ext (aardvark, subordinate_addr, flags, data_out):
+    """usage: (int return, u16 num_written) = aa_i2c_write_ext(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -667,18 +667,18 @@ def aa_i2c_write_ext (aardvark, slave_addr, flags, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_i2c_write_ext(aardvark, slave_addr, flags, num_bytes, data_out)
+    return api.py_aa_i2c_write_ext(aardvark, subordinate_addr, flags, num_bytes, data_out)
 
 
-# Do an atomic write+read to an I2C slave device by first
-# writing a stream of bytes to the I2C slave device and then
-# reading a stream of bytes back from the same slave device.
+# Do an atomic write+read to an I2C subordinate device by first
+# writing a stream of bytes to the I2C subordinate device and then
+# reading a stream of bytes back from the same subordinate device.
 # This API function returns the number of bytes written into
 # the num_written variable and the number of bytes read into
 # the num_read variable.  The return value of the function is
 # the status given as (read_status << 8) | (write_status).
-def aa_i2c_write_read (aardvark, slave_addr, flags, out_data, in_data):
-    """usage: (int return, u16 num_written, u08[] in_data, u16 num_read) = aa_i2c_write_read(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] out_data, u08[] in_data)
+def aa_i2c_write_read (aardvark, subordinate_addr, flags, out_data, in_data):
+    """usage: (int return, u16 num_written, u08[] in_data, u16 num_read) = aa_i2c_write_read(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] out_data, u08[] in_data)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -708,33 +708,33 @@ def aa_i2c_write_read (aardvark, slave_addr, flags, out_data, in_data):
         if in_data.typecode != 'B':
             raise TypeError("type for 'in_data' must be array('B')")
     # Call API function
-    (_ret_, num_written, num_read) = api.py_aa_i2c_write_read(aardvark, slave_addr, flags, out_num_bytes, out_data, in_num_bytes, in_data)
+    (_ret_, num_written, num_read) = api.py_aa_i2c_write_read(aardvark, subordinate_addr, flags, out_num_bytes, out_data, in_num_bytes, in_data)
     # in_data post-processing
     if __in_data: del in_data[max(0, min(num_read, len(in_data))):]
     return (_ret_, num_written, in_data, num_read)
 
 
-# Enable/Disable the Aardvark as an I2C slave device
-def aa_i2c_slave_enable (aardvark, addr, maxTxBytes, maxRxBytes):
-    """usage: int return = aa_i2c_slave_enable(Aardvark aardvark, u08 addr, u16 maxTxBytes, u16 maxRxBytes)"""
+# Enable/Disable the Aardvark as an I2C subordinate device
+def aa_i2c_subordinate_enable (aardvark, addr, maxTxBytes, maxRxBytes):
+    """usage: int return = aa_i2c_subordinate_enable(Aardvark aardvark, u08 addr, u16 maxTxBytes, u16 maxRxBytes)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_enable(aardvark, addr, maxTxBytes, maxRxBytes)
+    return api.py_aa_i2c_subordinate_enable(aardvark, addr, maxTxBytes, maxRxBytes)
 
 
-def aa_i2c_slave_disable (aardvark):
-    """usage: int return = aa_i2c_slave_disable(Aardvark aardvark)"""
+def aa_i2c_subordinate_disable (aardvark):
+    """usage: int return = aa_i2c_subordinate_disable(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_disable(aardvark)
+    return api.py_aa_i2c_subordinate_disable(aardvark)
 
 
-# Set the slave response in the event the Aardvark is put
-# into slave mode and contacted by a Master.
-def aa_i2c_slave_set_response (aardvark, data_out):
-    """usage: int return = aa_i2c_slave_set_response(Aardvark aardvark, u08[] data_out)
+# Set the subordinate response in the event the Aardvark is put
+# into subordinate mode and contacted by a Main.
+def aa_i2c_subordinate_set_response (aardvark, data_out):
+    """usage: int return = aa_i2c_subordinate_set_response(Aardvark aardvark, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -750,25 +750,25 @@ def aa_i2c_slave_set_response (aardvark, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_i2c_slave_set_response(aardvark, num_bytes, data_out)
+    return api.py_aa_i2c_subordinate_set_response(aardvark, num_bytes, data_out)
 
 
 # Return number of bytes written from a previous
-# Aardvark->I2C_master transmission.  Since the transmission is
+# Aardvark->I2C_main transmission.  Since the transmission is
 # happening asynchronously with respect to the PC host
 # software, there could be responses queued up from many
 # previous write transactions.
-def aa_i2c_slave_write_stats (aardvark):
-    """usage: int return = aa_i2c_slave_write_stats(Aardvark aardvark)"""
+def aa_i2c_subordinate_write_stats (aardvark):
+    """usage: int return = aa_i2c_subordinate_write_stats(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_write_stats(aardvark)
+    return api.py_aa_i2c_subordinate_write_stats(aardvark)
 
 
-# Read the bytes from an I2C slave reception
-def aa_i2c_slave_read (aardvark, data_in):
-    """usage: (int return, u08 addr, u08[] data_in) = aa_i2c_slave_read(Aardvark aardvark, u08[] data_in)
+# Read the bytes from an I2C subordinate reception
+def aa_i2c_subordinate_read (aardvark, data_in):
+    """usage: (int return, u08 addr, u08[] data_in) = aa_i2c_subordinate_read(Aardvark aardvark, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -794,23 +794,23 @@ def aa_i2c_slave_read (aardvark, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_, addr) = api.py_aa_i2c_slave_read(aardvark, num_bytes, data_in)
+    (_ret_, addr) = api.py_aa_i2c_subordinate_read(aardvark, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(_ret_, len(data_in))):]
     return (_ret_, addr, data_in)
 
 
 # Extended functions that return status code
-def aa_i2c_slave_write_stats_ext (aardvark):
-    """usage: (int return, u16 num_written) = aa_i2c_slave_write_stats_ext(Aardvark aardvark)"""
+def aa_i2c_subordinate_write_stats_ext (aardvark):
+    """usage: (int return, u16 num_written) = aa_i2c_subordinate_write_stats_ext(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_write_stats_ext(aardvark)
+    return api.py_aa_i2c_subordinate_write_stats_ext(aardvark)
 
 
-def aa_i2c_slave_read_ext (aardvark, data_in):
-    """usage: (int return, u08 addr, u08[] data_in, u16 num_read) = aa_i2c_slave_read_ext(Aardvark aardvark, u08[] data_in)
+def aa_i2c_subordinate_read_ext (aardvark, data_in):
+    """usage: (int return, u08 addr, u08[] data_in, u16 num_read) = aa_i2c_subordinate_read_ext(Aardvark aardvark, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -836,7 +836,7 @@ def aa_i2c_slave_read_ext (aardvark, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_, addr, num_read) = api.py_aa_i2c_slave_read_ext(aardvark, num_bytes, data_in)
+    (_ret_, addr, num_read) = api.py_aa_i2c_subordinate_read_ext(aardvark, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(num_read, len(data_in))):]
     return (_ret_, addr, data_in, num_read)
@@ -960,7 +960,7 @@ AA_SPI_PHASE_SETUP_SAMPLE = 1
 AA_SPI_BITORDER_MSB = 0
 AA_SPI_BITORDER_LSB = 1
 
-# Configure the SPI master or slave interface
+# Configure the SPI main or subordinate interface
 def aa_spi_configure (aardvark, polarity, phase, bitorder):
     """usage: int return = aa_spi_configure(Aardvark aardvark, AardvarkSpiPolarity polarity, AardvarkSpiPhase phase, AardvarkSpiBitorder bitorder)"""
 
@@ -969,7 +969,7 @@ def aa_spi_configure (aardvark, polarity, phase, bitorder):
     return api.py_aa_spi_configure(aardvark, polarity, phase, bitorder)
 
 
-# Write a stream of bytes to the downstream SPI slave device.
+# Write a stream of bytes to the downstream SPI subordinate device.
 def aa_spi_write (aardvark, data_out, data_in):
     """usage: (int return, u08[] data_in) = aa_spi_write(Aardvark aardvark, u08[] data_out, u08[] data_in)
 
@@ -1007,27 +1007,27 @@ def aa_spi_write (aardvark, data_out, data_in):
     return (_ret_, data_in)
 
 
-# Enable/Disable the Aardvark as an SPI slave device
-def aa_spi_slave_enable (aardvark):
-    """usage: int return = aa_spi_slave_enable(Aardvark aardvark)"""
+# Enable/Disable the Aardvark as an SPI subordinate device
+def aa_spi_subordinate_enable (aardvark):
+    """usage: int return = aa_spi_subordinate_enable(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_spi_slave_enable(aardvark)
+    return api.py_aa_spi_subordinate_enable(aardvark)
 
 
-def aa_spi_slave_disable (aardvark):
-    """usage: int return = aa_spi_slave_disable(Aardvark aardvark)"""
+def aa_spi_subordinate_disable (aardvark):
+    """usage: int return = aa_spi_subordinate_disable(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_spi_slave_disable(aardvark)
+    return api.py_aa_spi_subordinate_disable(aardvark)
 
 
-# Set the slave response in the event the Aardvark is put
-# into slave mode and contacted by a Master.
-def aa_spi_slave_set_response (aardvark, data_out):
-    """usage: int return = aa_spi_slave_set_response(Aardvark aardvark, u08[] data_out)
+# Set the subordinate response in the event the Aardvark is put
+# into subordinate mode and contacted by a Main.
+def aa_spi_subordinate_set_response (aardvark, data_out):
+    """usage: int return = aa_spi_subordinate_set_response(Aardvark aardvark, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -1043,12 +1043,12 @@ def aa_spi_slave_set_response (aardvark, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_spi_slave_set_response(aardvark, num_bytes, data_out)
+    return api.py_aa_spi_subordinate_set_response(aardvark, num_bytes, data_out)
 
 
-# Read the bytes from an SPI slave reception
-def aa_spi_slave_read (aardvark, data_in):
-    """usage: (int return, u08[] data_in) = aa_spi_slave_read(Aardvark aardvark, u08[] data_in)
+# Read the bytes from an SPI subordinate reception
+def aa_spi_subordinate_read (aardvark, data_in):
+    """usage: (int return, u08[] data_in) = aa_spi_subordinate_read(Aardvark aardvark, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -1074,7 +1074,7 @@ def aa_spi_slave_read (aardvark, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_) = api.py_aa_spi_slave_read(aardvark, num_bytes, data_in)
+    (_ret_) = api.py_aa_spi_subordinate_read(aardvark, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(_ret_, len(data_in))):]
     return (_ret_, data_in)
@@ -1082,19 +1082,19 @@ def aa_spi_slave_read (aardvark, data_in):
 
 # Change the output polarity on the SS line.
 #
-# Note: When configured as an SPI slave, the Aardvark will
+# Note: When configured as an SPI subordinate, the Aardvark will
 # always be setup with SS as active low.  Hence this function
-# only affects the SPI master functions on the Aardvark.
+# only affects the SPI main functions on the Aardvark.
 # enum AardvarkSpiSSPolarity
 AA_SPI_SS_ACTIVE_LOW  = 0
 AA_SPI_SS_ACTIVE_HIGH = 1
 
-def aa_spi_master_ss_polarity (aardvark, polarity):
-    """usage: int return = aa_spi_master_ss_polarity(Aardvark aardvark, AardvarkSpiSSPolarity polarity)"""
+def aa_spi_main_ss_polarity (aardvark, polarity):
+    """usage: int return = aa_spi_main_ss_polarity(Aardvark aardvark, AardvarkSpiSSPolarity polarity)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_spi_master_ss_polarity(aardvark, polarity)
+    return api.py_aa_spi_main_ss_polarity(aardvark, polarity)
 
 
 

--- a/PythonFiles/archive/minimalmodbus.py
+++ b/PythonFiles/archive/minimalmodbus.py
@@ -68,15 +68,15 @@ CLOSE_PORT_AFTER_EACH_CALL = True
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU protocol (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU protocol (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``/com3`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
 
     """
 
-    def __init__(self, port, slaveaddress):
+    def __init__(self, port, subordinateaddress):
 
         self.serial = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, \
             stopbits=STOPBITS, timeout=TIMEOUT)
@@ -97,8 +97,8 @@ class Instrument():
                 - Defaults to :data:`TIMEOUT`.
         """
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.debug = False
         """Set this to :const:`True` to print the communication details. Defaults to :const:`False`."""
@@ -123,14 +123,14 @@ class Instrument():
 
 
     ########################################
-    ## Functions for talking to the slave ##
+    ## Functions for talking to the subordinate ##
     ########################################
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -145,10 +145,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -165,17 +165,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -190,7 +190,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -210,21 +210,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -248,17 +248,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -277,9 +277,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -287,8 +287,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -307,9 +307,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -320,12 +320,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -344,17 +344,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -371,13 +371,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -395,16 +395,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -424,12 +424,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -450,17 +450,17 @@ class Instrument():
 
 
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -497,9 +497,9 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value. Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value. Same functionality also
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -597,25 +597,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -637,37 +637,37 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
         ## Communicate ##
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode == 16:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -675,7 +675,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -703,15 +703,15 @@ class Instrument():
     ## Communication implementation details ##
     ##########################################
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -720,23 +720,23 @@ class Instrument():
 
         """
         _checkFunctioncode(functioncode, None )
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
-        message             = _embedPayload(self.address, functioncode, payloadToSlave)
+        message             = _embedPayload(self.address, functioncode, payloadToSubordinate)
         response            = self._communicate(message)
-        payloadFromSlave    = _extractPayload(response, self.address, functioncode)
+        payloadFromSubordinate    = _extractPayload(response, self.address, functioncode)
 
-        return payloadFromSlave
+        return payloadFromSubordinate
 
 
     def _communicate(self, message):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            message (str): The raw message that is to be sent to the slave.
+            message (str): The raw message that is to be sent to the subordinate.
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -766,10 +766,10 @@ class Instrument():
             Note that these strings can look pretty strange when printed, as values 0 to 31 (dec) are
             ASCII control signs. For example 'vertical tab' and 'line feed' are among those.
 
-            The **raw message** to the slave has the frame format: slaveaddress byte + functioncode byte +
+            The **raw message** to the subordinate has the frame format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes).
 
-            The **received message** should have the format: slaveaddress byte + functioncode byte +
+            The **received message** should have the format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes)
 
             For Python3, the information sent to and from pySerial should be of the type bytes.
@@ -811,41 +811,41 @@ class Instrument():
 # Payload handling #
 ####################
 
-def _embedPayload(slaveaddress, functioncode, payloaddata):
-    """Build a message from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, functioncode, payloaddata):
+    """Build a message from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) message string for sending to the slave (including CRC etc).
+        The built (raw) message string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
-    The resulting message has the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+    The resulting message has the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
 
-    The CRC is calculated from the string made up of slaveaddress byte + functioncode byte + payloaddata.
+    The CRC is calculated from the string made up of subordinateaddress byte + functioncode byte + payloaddata.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
     # Build message
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
     message = firstPart + _calculateCrcString(firstPart)
     return message
 
 
-def _extractPayload(response, slaveaddress, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * functioncode (int): Used here for error checking only.
 
     Returns:
@@ -854,7 +854,7 @@ def _extractPayload(response, slaveaddress, functioncode):
     Raises:
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
-    The received message should have the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+    The received message should have the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
 
     """
     BYTEPOSITION_FOR_SLAVEADDRESS          = 0  # Zero-based counting
@@ -865,7 +865,7 @@ def _extractPayload(response, slaveaddress, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
 
     # Check CRC
@@ -879,18 +879,18 @@ def _extractPayload(response, slaveaddress, functioncode):
             _twoByteStringToNum(calculatedCRC), calculatedCRC,
             response))
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord( response[BYTEPOSITION_FOR_SLAVEADDRESS] )
 
-    if responseaddress != slaveaddress:
-        raise ValueError( 'Wrong return slave address: {0} instead of {1}. The response is: {2!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError( 'Wrong return subordinate address: {0} instead of {1}. The response is: {2!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord( response[BYTEPOSITION_FOR_FUNCTIONCODE ] )
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {0!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {0!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {0} instead of {1}. The response is: {2!r}'.format( \
@@ -942,8 +942,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1036,7 +1036,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1068,7 +1068,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1098,11 +1098,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1143,7 +1143,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1182,14 +1182,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1211,13 +1211,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1281,7 +1281,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -1646,11 +1646,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -1659,7 +1659,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):

--- a/TestCode/AlarmsTestScript.py
+++ b/TestCode/AlarmsTestScript.py
@@ -205,13 +205,13 @@ class SanityCheck:
             raise'FAILED'
 
 
-    def masterResettest(self):
+    def mainResettest(self):
         
         try:
             
             it.connect(com_port,baud)
             it.logging(True)
-            print '*' * 10,  'TEST: MasterResettest', '*' * 10
+            print '*' * 10,  'TEST: MainResettest', '*' * 10
                 #Verify hard reset
             for chn in [1,5,15,35,45,55,65,75,85]:
                 it.resena(0)
@@ -229,7 +229,7 @@ class SanityCheck:
                 turnOnLaser()
                 checkAlarms()
             it.disconnect()
-            print 'MasterReset Test Done...'
+            print 'MainReset Test Done...'
             
         except(IOError,ValueError):
             raise'FAILED'
@@ -601,8 +601,8 @@ class SanityCheck:
 
 
 
-    ##While laser on , send resena(sena=1, sr=0  ,mr=1)	Master Reset Triggered
-            print '*' * 10,'While laser on , send resena(sena=1, sr=0  ,mr=1)	Master Reset Triggered','*' * 10
+    ##While laser on , send resena(sena=1, sr=0  ,mr=1)	Main Reset Triggered
+            print '*' * 10,'While laser on , send resena(sena=1, sr=0  ,mr=1)	Main Reset Triggered','*' * 10
             print it.resena(1)
             addMarkers()
             print 'Clear Alarms...'
@@ -635,8 +635,8 @@ class SanityCheck:
 
 
             
-    ##While laser on , send resena(sr=0  ,mr=1)	Master Reset Triggered
-            print '*' * 10,'While laser on , send resena(sr=0  ,mr=1)	Master Reset Triggered','*' * 10
+    ##While laser on , send resena(sr=0  ,mr=1)	Main Reset Triggered
+            print '*' * 10,'While laser on , send resena(sr=0  ,mr=1)	Main Reset Triggered','*' * 10
             print it.resena(1)
             clearAlarms()
             pendingClear()
@@ -652,8 +652,8 @@ class SanityCheck:
             checkAlarms()
             it.oop()
             
-    ##While laser on , send resena(sr=1  ,mr=0)	Master Reset Triggered
-            print '*' * 10,'While laser on , send resena(sr=1  ,mr=0)	Master Reset Triggered','*' * 10
+    ##While laser on , send resena(sr=1  ,mr=0)	Main Reset Triggered
+            print '*' * 10,'While laser on , send resena(sr=1  ,mr=0)	Main Reset Triggered','*' * 10
             print it.resena(1)
             clearAlarms()
             pendingClear()
@@ -669,8 +669,8 @@ class SanityCheck:
             checkAlarms()
             it.oop()
             
-    ##While laser on , send resena(sr=1  ,mr=1)	Master Reset Triggered
-            print '*' * 10,'While laser on , send resena(sr=1  ,mr=1)	Master Reset Triggered','*' * 10
+    ##While laser on , send resena(sr=1  ,mr=1)	Main Reset Triggered
+            print '*' * 10,'While laser on , send resena(sr=1  ,mr=1)	Main Reset Triggered','*' * 10
             print it.resena(1)
             clearAlarms()
             pendingClear()
@@ -710,8 +710,8 @@ class SanityCheck:
             checkAlarms()
             it.oop()
             
-    ##While laser is off, send resena(sena=1, sr=0,  mr = 1)	Master Reset Triggered
-            print '*' * 10,'While laser is off, send resena(sena=1, sr=0,  mr = 1)	Master Reset Triggered','*' * 10
+    ##While laser is off, send resena(sena=1, sr=0,  mr = 1)	Main Reset Triggered
+            print '*' * 10,'While laser is off, send resena(sena=1, sr=0,  mr = 1)	Main Reset Triggered','*' * 10
             it.resena(0)
             print it.resena(sena=1,sr=0,mr=1)
             if unitType == 'dual':
@@ -726,8 +726,8 @@ class SanityCheck:
             it.oop()
 
 
-    ##While laser is off, send resena(sr=0,  mr = 1)	Master Reset Triggered
-            print '*' * 10,'While laser is off, send resena(sr=0,  mr = 1)	Master Reset Triggered','*' * 10
+    ##While laser is off, send resena(sr=0,  mr = 1)	Main Reset Triggered
+            print '*' * 10,'While laser is off, send resena(sr=0,  mr = 1)	Main Reset Triggered','*' * 10
             it.resena(0)
             print it.resena(sena=0,sr=0,mr=1)
             if unitType == 'dual':
@@ -742,8 +742,8 @@ class SanityCheck:
             it.oop()
 
 
-    ##While laser is off, send resena(sr=1,  mr = 0)	Master Reset Triggered
-            print '*' * 10,'While laser is off, send resena(sr=1,  mr = 0)	Master Reset Triggered','*' * 10
+    ##While laser is off, send resena(sr=1,  mr = 0)	Main Reset Triggered
+            print '*' * 10,'While laser is off, send resena(sr=1,  mr = 0)	Main Reset Triggered','*' * 10
             it.resena(0)
             print it.resena(sena=0,sr=1,mr=0)
             if unitType == 'dual':
@@ -758,8 +758,8 @@ class SanityCheck:
             it.oop()
 
 
-    ##While laser is off, send resena(sr=1,  mr = 1)	Master Reset Triggered
-            print '*' * 10,'While laser is off, send resena(sr=1,  mr = 1)	Master Reset Triggered','*' * 10
+    ##While laser is off, send resena(sr=1,  mr = 1)	Main Reset Triggered
+            print '*' * 10,'While laser is off, send resena(sr=1,  mr = 1)	Main Reset Triggered','*' * 10
             it.resena(0)
             print it.resena(sena=0,sr=1,mr=1)
             if unitType == 'dual':
@@ -1450,7 +1450,7 @@ if __name__== '__main__':
 ##        raise
 ##        
 ##    try:
-##        SanityCheck().masterResettest()
+##        SanityCheck().mainResettest()
 ##    except:
 ##        raise
 ##        

--- a/TestCode/AlarmsTestScriptversion14.py
+++ b/TestCode/AlarmsTestScriptversion14.py
@@ -1158,7 +1158,7 @@ class TestSrqTriggers:
         print it.srqT()
         self.it.statusF(1,1,1,1,1,1,1,1)
         self.it.statusW(1,1,1,1,1,1,1,1) #clear alarms
-        it.resena(mr=1)#trigger master reset
+        it.resena(mr=1)#trigger main reset
         time.sleep(3)
         print "==>> Show the alarm status after laser is tuned while the mrl is on"
         self.monitorParameters()
@@ -1176,7 +1176,7 @@ class TestSrqTriggers:
         print it.srqT()
         self.it.statusF(1,1,1,1,1,1,1,1)
         self.it.statusW(1,1,1,1,1,1,1,1) #clear alarms
-        it.resena(mr=1)#trigger master reset
+        it.resena(mr=1)#trigger main reset
         time.sleep(3)
         print "==>> Show the alarm status after laser is tuned while the mrl is on"
         self.monitorParameters()
@@ -1210,7 +1210,7 @@ class TestSrqTriggers:
         self.it.mcb(sdf=0,adt=1)
         self.it.resena(sena=1)#turn on the laser
         monChannellock()#wiat to chanel lock#monitor until channel lock
-        it.resena(mr=1)#trigger master reset
+        it.resena(mr=1)#trigger main reset
         self.it.srqT(0,0,0,0,0,0,0,0,1,0,0,0,0) #enable crl turn off everything
         print it.srqT()
         time.sleep(3)
@@ -1226,7 +1226,7 @@ class TestSrqTriggers:
         print "Turn on laser"
         self.it.resena(sena=1)#turn on the laser
         monChannellock()#wait to chanel lock#monitor until channel lock
-        it.resena(mr=1)#trigger master reset
+        it.resena(mr=1)#trigger main reset
         time.sleep(3)
         self.it.srqT(0,0,0,0,0,0,0,0,0,0,0,0,0) #enable dis turn off everything
         print it.srqT()
@@ -1804,7 +1804,7 @@ class TestFatalTriggers:
         monChannellock()#wiat to chanel lock#monitor until channel lock
         self.it.statusF(1,1,1,1,1,1,1,1)
         self.it.statusW(1,1,1,1,1,1,1,1) #clear alarms
-        it.resena(mr=1)#trigger master reset
+        it.resena(mr=1)#trigger main reset
         time.sleep(3)
         self.it.fatalT(0,0,0,0,1,0,0,0,0) #enable wtherml turn off everything
         print it.fatalT()
@@ -1822,7 +1822,7 @@ class TestFatalTriggers:
         monChannellock()#wait to chanel lock#monitor until channel lock
         self.it.statusF(1,1,1,1,1,1,1,1)
         self.it.statusW(1,1,1,1,1,1,1,1) #clear alarms
-        it.resena(mr=1)#trigger master reset
+        it.resena(mr=1)#trigger main reset
         time.sleep(3)
         self.it.fatalT(0,0,0,0,0,0,0,0,0) #enable wtherml turn off everything
         print it.fatalT()

--- a/TestCode/CheckPendingBit_revision19.py
+++ b/TestCode/CheckPendingBit_revision19.py
@@ -891,7 +891,7 @@ class PendingBitTest:
 
     def runpendingtestCase14(self):
     
-        ''' while laser off, set to channel, turn on laser, monitor nop after 5 sec trigger master reset'''
+        ''' while laser off, set to channel, turn on laser, monitor nop after 5 sec trigger main reset'''
         self.it.connect(_PORT,_BAUD)       #connect
         self.it.logging(True)
         self.it.logfile(self.logfilename14)  #enable logging
@@ -935,9 +935,9 @@ class PendingBitTest:
                     self.lapseTime = time.time() -  self.startTime  #keep counting time
                     print(self.lapseTime, self.pending, self.lf, self.oop, self.ftf, self.statusF, self.statusW, self.tunerstate) #print these parameters
                     
-                    if self.lapseTime >= 5.0: #After 5 secs,trigger master reset
-                        print("==>Trigger master Reset...")
-                        self.it.resena(mr = 1) # trigger master reset
+                    if self.lapseTime >= 5.0: #After 5 secs,trigger main reset
+                        print("==>Trigger main Reset...")
+                        self.it.resena(mr = 1) # trigger main reset
                         #time.sleep(3)
                         for rep in range(5): #print 5 times
                             self.it.setpassword()

--- a/TestCode/Driver/instrumentDrivers.py
+++ b/TestCode/Driver/instrumentDrivers.py
@@ -149,7 +149,7 @@ class pmHP8163:
         return float(self.inst.ask(cmd))
 
     def triggerReadPower(self):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.inst.write( ':INIT%d:CHAN1:TRIG:IMM' % self.slot)
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.slot, self.head)

--- a/TestCode/Driver/minimalmodbus.py
+++ b/TestCode/Driver/minimalmodbus.py
@@ -68,15 +68,15 @@ CLOSE_PORT_AFTER_EACH_CALL = True
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU protocol (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU protocol (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``/com3`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
 
     """
 
-    def __init__(self, port, slaveaddress):
+    def __init__(self, port, subordinateaddress):
 
         self.serial = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, \
             stopbits=STOPBITS, timeout=TIMEOUT)
@@ -97,8 +97,8 @@ class Instrument():
                 - Defaults to :data:`TIMEOUT`.
         """
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.debug = False
         """Set this to :const:`True` to print the communication details. Defaults to :const:`False`."""
@@ -123,14 +123,14 @@ class Instrument():
 
 
     ########################################
-    ## Functions for talking to the slave ##
+    ## Functions for talking to the subordinate ##
     ########################################
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -145,10 +145,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -165,17 +165,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -190,7 +190,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -210,21 +210,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -248,17 +248,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -277,9 +277,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -287,8 +287,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -307,9 +307,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -320,12 +320,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -344,17 +344,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -371,13 +371,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -395,16 +395,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -424,12 +424,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -450,17 +450,17 @@ class Instrument():
 
 
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -497,9 +497,9 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value. Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value. Same functionality also
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -597,25 +597,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -637,37 +637,37 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
         ## Communicate ##
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode == 16:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -675,7 +675,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -703,15 +703,15 @@ class Instrument():
     ## Communication implementation details ##
     ##########################################
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -720,23 +720,23 @@ class Instrument():
 
         """
         _checkFunctioncode(functioncode, None )
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
-        message             = _embedPayload(self.address, functioncode, payloadToSlave)
+        message             = _embedPayload(self.address, functioncode, payloadToSubordinate)
         response            = self._communicate(message)
-        payloadFromSlave    = _extractPayload(response, self.address, functioncode)
+        payloadFromSubordinate    = _extractPayload(response, self.address, functioncode)
 
-        return payloadFromSlave
+        return payloadFromSubordinate
 
 
     def _communicate(self, message):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            message (str): The raw message that is to be sent to the slave.
+            message (str): The raw message that is to be sent to the subordinate.
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -766,10 +766,10 @@ class Instrument():
             Note that these strings can look pretty strange when printed, as values 0 to 31 (dec) are
             ASCII control signs. For example 'vertical tab' and 'line feed' are among those.
 
-            The **raw message** to the slave has the frame format: slaveaddress byte + functioncode byte +
+            The **raw message** to the subordinate has the frame format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes).
 
-            The **received message** should have the format: slaveaddress byte + functioncode byte +
+            The **received message** should have the format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes)
 
             For Python3, the information sent to and from pySerial should be of the type bytes.
@@ -811,41 +811,41 @@ class Instrument():
 # Payload handling #
 ####################
 
-def _embedPayload(slaveaddress, functioncode, payloaddata):
-    """Build a message from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, functioncode, payloaddata):
+    """Build a message from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) message string for sending to the slave (including CRC etc).
+        The built (raw) message string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
-    The resulting message has the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+    The resulting message has the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
 
-    The CRC is calculated from the string made up of slaveaddress byte + functioncode byte + payloaddata.
+    The CRC is calculated from the string made up of subordinateaddress byte + functioncode byte + payloaddata.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
     # Build message
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
     message = firstPart + _calculateCrcString(firstPart)
     return message
 
 
-def _extractPayload(response, slaveaddress, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * functioncode (int): Used here for error checking only.
 
     Returns:
@@ -854,7 +854,7 @@ def _extractPayload(response, slaveaddress, functioncode):
     Raises:
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
-    The received message should have the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+    The received message should have the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
 
     """
     BYTEPOSITION_FOR_SLAVEADDRESS          = 0  # Zero-based counting
@@ -865,7 +865,7 @@ def _extractPayload(response, slaveaddress, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
 
     # Check CRC
@@ -879,18 +879,18 @@ def _extractPayload(response, slaveaddress, functioncode):
             _twoByteStringToNum(calculatedCRC), calculatedCRC,
             response))
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord( response[BYTEPOSITION_FOR_SLAVEADDRESS] )
 
-    if responseaddress != slaveaddress:
-        raise ValueError( 'Wrong return slave address: {0} instead of {1}. The response is: {2!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError( 'Wrong return subordinate address: {0} instead of {1}. The response is: {2!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord( response[BYTEPOSITION_FOR_FUNCTIONCODE ] )
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {0!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {0!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {0} instead of {1}. The response is: {2!r}'.format( \
@@ -942,8 +942,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1036,7 +1036,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1068,7 +1068,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1098,11 +1098,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1143,7 +1143,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1182,14 +1182,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1211,13 +1211,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1281,7 +1281,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -1646,11 +1646,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -1659,7 +1659,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):

--- a/TestCode/GUI/CheckButtonGettingStatus.py
+++ b/TestCode/GUI/CheckButtonGettingStatus.py
@@ -14,11 +14,11 @@ import Tkinter
 root=Tk()
 
 class CheckB():
-    def __init__(self, master, text):
+    def __init__(self, main, text):
         self.var = IntVar()
         self.text=text
         c = Checkbutton(
-            master, text=text,
+            main, text=text,
             variable=self.var,
             command=self.check)
         c.pack()

--- a/TestCode/GUI/MainGui.py
+++ b/TestCode/GUI/MainGui.py
@@ -10,11 +10,11 @@ import Tkinter as Tk
 #esablish the size of the rootwindow
 
 class CheckButton():
-    def __init__(self, master, text):
+    def __init__(self, main, text):
         self.var = Tk.IntVar()
         self.text=text
         c = Tk.Checkbutton(
-            master, text=text,
+            main, text=text,
             variable=self.var,
             command=self.check)
         c.pack()
@@ -38,7 +38,7 @@ class MainGui(CheckB):
         self.root.title("RT GUI")   # add a title to the root window
         self.root.geometry("800x800")
         self.root.resizable(0,0)
-        self.frame = Tk.Frame(master = self.root,width=1000, height=1000, bg='blue')
+        self.frame = Tk.Frame(main = self.root,width=1000, height=1000, bg='blue')
         self.addCheckbutton()
         self.frame.pack()
  # this is where you put the dimension of the frame

--- a/TestCode/GUI/MainGui_rev1.py
+++ b/TestCode/GUI/MainGui_rev1.py
@@ -10,11 +10,11 @@ import Tkinter as Tk
 #esablish the size of the rootwindow
 
 class CheckButton():
-    def __init__(self, master, text):
+    def __init__(self, main, text):
         self.var = Tk.IntVar()
         self.text=text
         c = Tk.Checkbutton(
-            master, text=text,
+            main, text=text,
             variable=self.var,
             command=self.check)
         #c.pack()
@@ -42,7 +42,7 @@ class MainGui:
         self.root.grid_columnconfigure(0, weight = 
         
         #create the containers or frames color blue
-        self.frame = Tk.Frame(master = self.root,bg = 'blue', width=100, height=100,\
+        self.frame = Tk.Frame(main = self.root,bg = 'blue', width=100, height=100,\
                               pady = 1)
        
         #assign a location for this frame

--- a/TestCode/GUI/MainGui_rev2.py
+++ b/TestCode/GUI/MainGui_rev2.py
@@ -10,11 +10,11 @@ import Tkinter as Tk
 #esablish the size of the rootwindow
 
 class CheckButton():
-    def __init__(self, master, text, row = None):
+    def __init__(self, main, text, row = None):
         self.var = Tk.IntVar()
         self.text=text
         c = Tk.Checkbutton(
-            master, activebackground = "red",\
+            main, activebackground = "red",\
             activeforeground = "yellow",\
             bg = "blue",\
             bitmap = None,\
@@ -50,7 +50,7 @@ class MainGui:
  
  
         #create the containers or frames color blue
-        self.frame = Tk.Frame(master = self.root,bg = 'blue', width=500, height=500,\
+        self.frame = Tk.Frame(main = self.root,bg = 'blue', width=500, height=500,\
                               pady = 1)
         self.label = Tk.Label(self.frame,text ="NANO RT")
         self.label.grid(row = 0, sticky = 'n')

--- a/TestCode/GUI/MainGui_rev3.py
+++ b/TestCode/GUI/MainGui_rev3.py
@@ -10,11 +10,11 @@ import Tkinter as Tk
 #esablish the size of the rootwindow
 
 class CheckButton():
-    def __init__(self, master, text, row = None):
+    def __init__(self, main, text, row = None):
         self.var = Tk.IntVar()
         self.text=text
         c = Tk.Checkbutton(
-            master, activebackground = "red",\
+            main, activebackground = "red",\
             activeforeground = "yellow",\
             bg = "blue",\
             bitmap = None,\
@@ -51,7 +51,7 @@ class MainGui:
  
  
         #create the containers or frames color blue
-        self.frame = Tk.Frame(master = self.root,bg = 'blue', width=500, height=500,\
+        self.frame = Tk.Frame(main = self.root,bg = 'blue', width=500, height=500,\
                               pady = 1)
         self.label = Tk.Label(self.frame,text ="NANO RT")
         self.label.grid(row = 0, sticky = 'n')

--- a/TestCode/Main.py
+++ b/TestCode/Main.py
@@ -35,7 +35,7 @@ elif (HUAWEI == 1) or (GENERIC == 1) or (BASIC== 1) or (FW_UPGRADE == 1):
     import RandomFtfTestSuite as RFTFTS
     import ReadOnlyRegisterTestSuite as RORTS
     import EchoResetTestRelease as ERTR
-    import MasterResetTestRelease as MRTR
+    import MainResetTestRelease as MRTR
     import SoftResetTestRelease as SRTR
     import PowerCycleTestRelease as PCTR
     import HwSoftResetTestRelease as HWSRTR
@@ -94,7 +94,7 @@ if __name__ == '__main__':
             SCTS.SanityCheck().laserDisabletest(g)
             SCTS.SanityCheck().moduleSelecttest(g)
             SCTS.SanityCheck().hardResettest(g)
-            SCTS.SanityCheck().masterResettest()
+            SCTS.SanityCheck().mainResettest()
             SCTS.SanityCheck().softResettest()
             SCTS.SanityCheck().adtTest()
             SCTS.SanityCheck().genConfigtest()
@@ -168,7 +168,7 @@ if __name__ == '__main__':
             raise      
             
         try:
-            mrtr = MRTR.MasterResetTest()
+            mrtr = MRTR.MainResetTest()
             mrtr.runTest()#run ECHO Reset Test
         except:
             raise
@@ -270,8 +270,8 @@ if __name__ == '__main__':
 
 
         try:
-            mrtr = MRTR.MasterResetTest()
-            mrtr.runTest()#run Master Reset Test
+            mrtr = MRTR.MainResetTest()
+            mrtr.runTest()#run Main Reset Test
         except:
             raise                        
             

--- a/TestCode/PyVISA_/docs/conf.py
+++ b/TestCode/PyVISA_/docs/conf.py
@@ -38,8 +38,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'PyVISA'

--- a/TestCode/SanityCheckTestSuite.py
+++ b/TestCode/SanityCheckTestSuite.py
@@ -200,13 +200,13 @@ class SanityCheck:
             raise'FAILED'
 
 
-    def masterResettest(self):
+    def mainResettest(self):
         
         try:
             
             it.connect(com_port,baud)
             it.logging(True)
-            print '*' * 10,  'TEST: MasterResettest', '*' * 10
+            print '*' * 10,  'TEST: MainResettest', '*' * 10
                 #Verify hard reset
             for chn in [1,5,15,35,45,55,65,75,85]:
                 it.resena(0)
@@ -224,7 +224,7 @@ class SanityCheck:
                 turnOnLaser()
                 checkAlarms()
             it.disconnect()
-            print 'MasterReset Test Done...'
+            print 'MainReset Test Done...'
             
         except(IOError,ValueError):
             raise'FAILED'
@@ -596,8 +596,8 @@ class SanityCheck:
 
 
 
-    ##While laser on , send resena(sena=1, sr=0  ,mr=1)	Master Reset Triggered
-            print '*' * 10,'While laser on , send resena(sena=1, sr=0  ,mr=1)	Master Reset Triggered','*' * 10
+    ##While laser on , send resena(sena=1, sr=0  ,mr=1)	Main Reset Triggered
+            print '*' * 10,'While laser on , send resena(sena=1, sr=0  ,mr=1)	Main Reset Triggered','*' * 10
             print it.resena(1)
             addMarkers()
             print 'Clear Alarms...'
@@ -630,8 +630,8 @@ class SanityCheck:
 
 
             
-    ##While laser on , send resena(sr=0  ,mr=1)	Master Reset Triggered
-            print '*' * 10,'While laser on , send resena(sr=0  ,mr=1)	Master Reset Triggered','*' * 10
+    ##While laser on , send resena(sr=0  ,mr=1)	Main Reset Triggered
+            print '*' * 10,'While laser on , send resena(sr=0  ,mr=1)	Main Reset Triggered','*' * 10
             print it.resena(1)
             clearAlarms()
             pendingClear()
@@ -647,8 +647,8 @@ class SanityCheck:
             checkAlarms()
             it.oop()
             
-    ##While laser on , send resena(sr=1  ,mr=0)	Master Reset Triggered
-            print '*' * 10,'While laser on , send resena(sr=1  ,mr=0)	Master Reset Triggered','*' * 10
+    ##While laser on , send resena(sr=1  ,mr=0)	Main Reset Triggered
+            print '*' * 10,'While laser on , send resena(sr=1  ,mr=0)	Main Reset Triggered','*' * 10
             print it.resena(1)
             clearAlarms()
             pendingClear()
@@ -664,8 +664,8 @@ class SanityCheck:
             checkAlarms()
             it.oop()
             
-    ##While laser on , send resena(sr=1  ,mr=1)	Master Reset Triggered
-            print '*' * 10,'While laser on , send resena(sr=1  ,mr=1)	Master Reset Triggered','*' * 10
+    ##While laser on , send resena(sr=1  ,mr=1)	Main Reset Triggered
+            print '*' * 10,'While laser on , send resena(sr=1  ,mr=1)	Main Reset Triggered','*' * 10
             print it.resena(1)
             clearAlarms()
             pendingClear()
@@ -705,8 +705,8 @@ class SanityCheck:
             checkAlarms()
             it.oop()
             
-    ##While laser is off, send resena(sena=1, sr=0,  mr = 1)	Master Reset Triggered
-            print '*' * 10,'While laser is off, send resena(sena=1, sr=0,  mr = 1)	Master Reset Triggered','*' * 10
+    ##While laser is off, send resena(sena=1, sr=0,  mr = 1)	Main Reset Triggered
+            print '*' * 10,'While laser is off, send resena(sena=1, sr=0,  mr = 1)	Main Reset Triggered','*' * 10
             it.resena(0)
             print it.resena(sena=1,sr=0,mr=1)
             if unitType == 'dual':
@@ -721,8 +721,8 @@ class SanityCheck:
             it.oop()
 
 
-    ##While laser is off, send resena(sr=0,  mr = 1)	Master Reset Triggered
-            print '*' * 10,'While laser is off, send resena(sr=0,  mr = 1)	Master Reset Triggered','*' * 10
+    ##While laser is off, send resena(sr=0,  mr = 1)	Main Reset Triggered
+            print '*' * 10,'While laser is off, send resena(sr=0,  mr = 1)	Main Reset Triggered','*' * 10
             it.resena(0)
             print it.resena(sena=0,sr=0,mr=1)
             if unitType == 'dual':
@@ -737,8 +737,8 @@ class SanityCheck:
             it.oop()
 
 
-    ##While laser is off, send resena(sr=1,  mr = 0)	Master Reset Triggered
-            print '*' * 10,'While laser is off, send resena(sr=1,  mr = 0)	Master Reset Triggered','*' * 10
+    ##While laser is off, send resena(sr=1,  mr = 0)	Main Reset Triggered
+            print '*' * 10,'While laser is off, send resena(sr=1,  mr = 0)	Main Reset Triggered','*' * 10
             it.resena(0)
             print it.resena(sena=0,sr=1,mr=0)
             if unitType == 'dual':
@@ -753,8 +753,8 @@ class SanityCheck:
             it.oop()
 
 
-    ##While laser is off, send resena(sr=1,  mr = 1)	Master Reset Triggered
-            print '*' * 10,'While laser is off, send resena(sr=1,  mr = 1)	Master Reset Triggered','*' * 10
+    ##While laser is off, send resena(sr=1,  mr = 1)	Main Reset Triggered
+            print '*' * 10,'While laser is off, send resena(sr=1,  mr = 1)	Main Reset Triggered','*' * 10
             it.resena(0)
             print it.resena(sena=0,sr=1,mr=1)
             if unitType == 'dual':
@@ -1117,7 +1117,7 @@ if __name__== '__main__':
 ##        raise
         
     try:
-        SanityCheck().masterResettest()
+        SanityCheck().mainResettest()
     except:
         raise
         

--- a/TestCode/TestScripts/Chan_Pwr_Tune_Test/InstrumentDrivers_DS.py
+++ b/TestCode/TestScripts/Chan_Pwr_Tune_Test/InstrumentDrivers_DS.py
@@ -819,7 +819,7 @@ class Agilent8163B(Base):
 
 
     def getDisplayedPower(self, queryDelay = 0.002):
-        #getPower() will not work for the slave module, so we need to read the display with FETCH
+        #getPower() will not work for the subordinate module, so we need to read the display with FETCH
         cmd = 'FETC%d:CHAN%d:POW?'%(self._conf[self._ActiveConf][0],self._conf[self._ActiveConf][1])
         reply = self.query(cmd, delay=queryDelay)
         try:
@@ -877,7 +877,7 @@ class Agilent8163B(Base):
 
     #<DS>
     def triggerReadPower(self, fltQueryDelay = 0.05):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.write( ':INIT%d:CHAN1:TRIG:IMM' % self.getSlot())
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.getSlot(),self.getHead())

--- a/TestCode/TestScripts/Gencfg_PwrSupply/InstrumentDrivers_DS.py
+++ b/TestCode/TestScripts/Gencfg_PwrSupply/InstrumentDrivers_DS.py
@@ -819,7 +819,7 @@ class Agilent8163B(Base):
 
 
     def getDisplayedPower(self, queryDelay = 0.002):
-        #getPower() will not work for the slave module, so we need to read the display with FETCH
+        #getPower() will not work for the subordinate module, so we need to read the display with FETCH
         cmd = 'FETC%d:CHAN%d:POW?'%(self._conf[self._ActiveConf][0],self._conf[self._ActiveConf][1])
         reply = self.query(cmd, delay=queryDelay)
         try:
@@ -877,7 +877,7 @@ class Agilent8163B(Base):
 
     #<DS>
     def triggerReadPower(self, fltQueryDelay = 0.05):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.write( ':INIT%d:CHAN1:TRIG:IMM' % self.getSlot())
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.getSlot(),self.getHead())

--- a/TestCode/TestScripts/Gencfg_PwrSupply_Test/InstrumentDrivers_DS.py
+++ b/TestCode/TestScripts/Gencfg_PwrSupply_Test/InstrumentDrivers_DS.py
@@ -819,7 +819,7 @@ class Agilent8163B(Base):
 
 
     def getDisplayedPower(self, queryDelay = 0.002):
-        #getPower() will not work for the slave module, so we need to read the display with FETCH
+        #getPower() will not work for the subordinate module, so we need to read the display with FETCH
         cmd = 'FETC%d:CHAN%d:POW?'%(self._conf[self._ActiveConf][0],self._conf[self._ActiveConf][1])
         reply = self.query(cmd, delay=queryDelay)
         try:
@@ -877,7 +877,7 @@ class Agilent8163B(Base):
 
     #<DS>
     def triggerReadPower(self, fltQueryDelay = 0.05):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.write( ':INIT%d:CHAN1:TRIG:IMM' % self.getSlot())
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.getSlot(),self.getHead())

--- a/TestCode/aa_gpio/aardvark_py.py
+++ b/TestCode/aa_gpio/aardvark_py.py
@@ -544,9 +544,9 @@ AA_I2C_NO_STOP           = 0x04
 AA_I2C_SIZED_READ        = 0x10
 AA_I2C_SIZED_READ_EXTRA1 = 0x20
 
-# Read a stream of bytes from the I2C slave device.
-def aa_i2c_read (aardvark, slave_addr, flags, data_in):
-    """usage: (int return, u08[] data_in) = aa_i2c_read(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_in)
+# Read a stream of bytes from the I2C subordinate device.
+def aa_i2c_read (aardvark, subordinate_addr, flags, data_in):
+    """usage: (int return, u08[] data_in) = aa_i2c_read(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -572,7 +572,7 @@ def aa_i2c_read (aardvark, slave_addr, flags, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_) = api.py_aa_i2c_read(aardvark, slave_addr, flags, num_bytes, data_in)
+    (_ret_) = api.py_aa_i2c_read(aardvark, subordinate_addr, flags, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(_ret_, len(data_in))):]
     return (_ret_, data_in)
@@ -588,12 +588,12 @@ AA_I2C_STATUS_ARB_LOST      = 5
 AA_I2C_STATUS_BUS_LOCKED    = 6
 AA_I2C_STATUS_LAST_DATA_ACK = 7
 
-# Read a stream of bytes from the I2C slave device.
+# Read a stream of bytes from the I2C subordinate device.
 # This API function returns the number of bytes read into
 # the num_read variable.  The return value of the function
 # is a status code.
-def aa_i2c_read_ext (aardvark, slave_addr, flags, data_in):
-    """usage: (int return, u08[] data_in, u16 num_read) = aa_i2c_read_ext(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_in)
+def aa_i2c_read_ext (aardvark, subordinate_addr, flags, data_in):
+    """usage: (int return, u08[] data_in, u16 num_read) = aa_i2c_read_ext(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -619,15 +619,15 @@ def aa_i2c_read_ext (aardvark, slave_addr, flags, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_, num_read) = api.py_aa_i2c_read_ext(aardvark, slave_addr, flags, num_bytes, data_in)
+    (_ret_, num_read) = api.py_aa_i2c_read_ext(aardvark, subordinate_addr, flags, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(num_read, len(data_in))):]
     return (_ret_, data_in, num_read)
 
 
-# Write a stream of bytes to the I2C slave device.
-def aa_i2c_write (aardvark, slave_addr, flags, data_out):
-    """usage: int return = aa_i2c_write(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_out)
+# Write a stream of bytes to the I2C subordinate device.
+def aa_i2c_write (aardvark, subordinate_addr, flags, data_out):
+    """usage: int return = aa_i2c_write(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -643,15 +643,15 @@ def aa_i2c_write (aardvark, slave_addr, flags, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_i2c_write(aardvark, slave_addr, flags, num_bytes, data_out)
+    return api.py_aa_i2c_write(aardvark, subordinate_addr, flags, num_bytes, data_out)
 
 
-# Write a stream of bytes to the I2C slave device.
+# Write a stream of bytes to the I2C subordinate device.
 # This API function returns the number of bytes written into
 # the num_written variable.  The return value of the function
 # is a status code.
-def aa_i2c_write_ext (aardvark, slave_addr, flags, data_out):
-    """usage: (int return, u16 num_written) = aa_i2c_write_ext(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_out)
+def aa_i2c_write_ext (aardvark, subordinate_addr, flags, data_out):
+    """usage: (int return, u16 num_written) = aa_i2c_write_ext(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -667,18 +667,18 @@ def aa_i2c_write_ext (aardvark, slave_addr, flags, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_i2c_write_ext(aardvark, slave_addr, flags, num_bytes, data_out)
+    return api.py_aa_i2c_write_ext(aardvark, subordinate_addr, flags, num_bytes, data_out)
 
 
-# Do an atomic write+read to an I2C slave device by first
-# writing a stream of bytes to the I2C slave device and then
-# reading a stream of bytes back from the same slave device.
+# Do an atomic write+read to an I2C subordinate device by first
+# writing a stream of bytes to the I2C subordinate device and then
+# reading a stream of bytes back from the same subordinate device.
 # This API function returns the number of bytes written into
 # the num_written variable and the number of bytes read into
 # the num_read variable.  The return value of the function is
 # the status given as (read_status << 8) | (write_status).
-def aa_i2c_write_read (aardvark, slave_addr, flags, out_data, in_data):
-    """usage: (int return, u16 num_written, u08[] in_data, u16 num_read) = aa_i2c_write_read(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] out_data, u08[] in_data)
+def aa_i2c_write_read (aardvark, subordinate_addr, flags, out_data, in_data):
+    """usage: (int return, u16 num_written, u08[] in_data, u16 num_read) = aa_i2c_write_read(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] out_data, u08[] in_data)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -708,33 +708,33 @@ def aa_i2c_write_read (aardvark, slave_addr, flags, out_data, in_data):
         if in_data.typecode != 'B':
             raise TypeError("type for 'in_data' must be array('B')")
     # Call API function
-    (_ret_, num_written, num_read) = api.py_aa_i2c_write_read(aardvark, slave_addr, flags, out_num_bytes, out_data, in_num_bytes, in_data)
+    (_ret_, num_written, num_read) = api.py_aa_i2c_write_read(aardvark, subordinate_addr, flags, out_num_bytes, out_data, in_num_bytes, in_data)
     # in_data post-processing
     if __in_data: del in_data[max(0, min(num_read, len(in_data))):]
     return (_ret_, num_written, in_data, num_read)
 
 
-# Enable/Disable the Aardvark as an I2C slave device
-def aa_i2c_slave_enable (aardvark, addr, maxTxBytes, maxRxBytes):
-    """usage: int return = aa_i2c_slave_enable(Aardvark aardvark, u08 addr, u16 maxTxBytes, u16 maxRxBytes)"""
+# Enable/Disable the Aardvark as an I2C subordinate device
+def aa_i2c_subordinate_enable (aardvark, addr, maxTxBytes, maxRxBytes):
+    """usage: int return = aa_i2c_subordinate_enable(Aardvark aardvark, u08 addr, u16 maxTxBytes, u16 maxRxBytes)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_enable(aardvark, addr, maxTxBytes, maxRxBytes)
+    return api.py_aa_i2c_subordinate_enable(aardvark, addr, maxTxBytes, maxRxBytes)
 
 
-def aa_i2c_slave_disable (aardvark):
-    """usage: int return = aa_i2c_slave_disable(Aardvark aardvark)"""
+def aa_i2c_subordinate_disable (aardvark):
+    """usage: int return = aa_i2c_subordinate_disable(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_disable(aardvark)
+    return api.py_aa_i2c_subordinate_disable(aardvark)
 
 
-# Set the slave response in the event the Aardvark is put
-# into slave mode and contacted by a Master.
-def aa_i2c_slave_set_response (aardvark, data_out):
-    """usage: int return = aa_i2c_slave_set_response(Aardvark aardvark, u08[] data_out)
+# Set the subordinate response in the event the Aardvark is put
+# into subordinate mode and contacted by a Main.
+def aa_i2c_subordinate_set_response (aardvark, data_out):
+    """usage: int return = aa_i2c_subordinate_set_response(Aardvark aardvark, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -750,25 +750,25 @@ def aa_i2c_slave_set_response (aardvark, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_i2c_slave_set_response(aardvark, num_bytes, data_out)
+    return api.py_aa_i2c_subordinate_set_response(aardvark, num_bytes, data_out)
 
 
 # Return number of bytes written from a previous
-# Aardvark->I2C_master transmission.  Since the transmission is
+# Aardvark->I2C_main transmission.  Since the transmission is
 # happening asynchronously with respect to the PC host
 # software, there could be responses queued up from many
 # previous write transactions.
-def aa_i2c_slave_write_stats (aardvark):
-    """usage: int return = aa_i2c_slave_write_stats(Aardvark aardvark)"""
+def aa_i2c_subordinate_write_stats (aardvark):
+    """usage: int return = aa_i2c_subordinate_write_stats(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_write_stats(aardvark)
+    return api.py_aa_i2c_subordinate_write_stats(aardvark)
 
 
-# Read the bytes from an I2C slave reception
-def aa_i2c_slave_read (aardvark, data_in):
-    """usage: (int return, u08 addr, u08[] data_in) = aa_i2c_slave_read(Aardvark aardvark, u08[] data_in)
+# Read the bytes from an I2C subordinate reception
+def aa_i2c_subordinate_read (aardvark, data_in):
+    """usage: (int return, u08 addr, u08[] data_in) = aa_i2c_subordinate_read(Aardvark aardvark, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -794,23 +794,23 @@ def aa_i2c_slave_read (aardvark, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_, addr) = api.py_aa_i2c_slave_read(aardvark, num_bytes, data_in)
+    (_ret_, addr) = api.py_aa_i2c_subordinate_read(aardvark, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(_ret_, len(data_in))):]
     return (_ret_, addr, data_in)
 
 
 # Extended functions that return status code
-def aa_i2c_slave_write_stats_ext (aardvark):
-    """usage: (int return, u16 num_written) = aa_i2c_slave_write_stats_ext(Aardvark aardvark)"""
+def aa_i2c_subordinate_write_stats_ext (aardvark):
+    """usage: (int return, u16 num_written) = aa_i2c_subordinate_write_stats_ext(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_write_stats_ext(aardvark)
+    return api.py_aa_i2c_subordinate_write_stats_ext(aardvark)
 
 
-def aa_i2c_slave_read_ext (aardvark, data_in):
-    """usage: (int return, u08 addr, u08[] data_in, u16 num_read) = aa_i2c_slave_read_ext(Aardvark aardvark, u08[] data_in)
+def aa_i2c_subordinate_read_ext (aardvark, data_in):
+    """usage: (int return, u08 addr, u08[] data_in, u16 num_read) = aa_i2c_subordinate_read_ext(Aardvark aardvark, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -836,7 +836,7 @@ def aa_i2c_slave_read_ext (aardvark, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_, addr, num_read) = api.py_aa_i2c_slave_read_ext(aardvark, num_bytes, data_in)
+    (_ret_, addr, num_read) = api.py_aa_i2c_subordinate_read_ext(aardvark, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(num_read, len(data_in))):]
     return (_ret_, addr, data_in, num_read)
@@ -960,7 +960,7 @@ AA_SPI_PHASE_SETUP_SAMPLE = 1
 AA_SPI_BITORDER_MSB = 0
 AA_SPI_BITORDER_LSB = 1
 
-# Configure the SPI master or slave interface
+# Configure the SPI main or subordinate interface
 def aa_spi_configure (aardvark, polarity, phase, bitorder):
     """usage: int return = aa_spi_configure(Aardvark aardvark, AardvarkSpiPolarity polarity, AardvarkSpiPhase phase, AardvarkSpiBitorder bitorder)"""
 
@@ -969,7 +969,7 @@ def aa_spi_configure (aardvark, polarity, phase, bitorder):
     return api.py_aa_spi_configure(aardvark, polarity, phase, bitorder)
 
 
-# Write a stream of bytes to the downstream SPI slave device.
+# Write a stream of bytes to the downstream SPI subordinate device.
 def aa_spi_write (aardvark, data_out, data_in):
     """usage: (int return, u08[] data_in) = aa_spi_write(Aardvark aardvark, u08[] data_out, u08[] data_in)
 
@@ -1007,27 +1007,27 @@ def aa_spi_write (aardvark, data_out, data_in):
     return (_ret_, data_in)
 
 
-# Enable/Disable the Aardvark as an SPI slave device
-def aa_spi_slave_enable (aardvark):
-    """usage: int return = aa_spi_slave_enable(Aardvark aardvark)"""
+# Enable/Disable the Aardvark as an SPI subordinate device
+def aa_spi_subordinate_enable (aardvark):
+    """usage: int return = aa_spi_subordinate_enable(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_spi_slave_enable(aardvark)
+    return api.py_aa_spi_subordinate_enable(aardvark)
 
 
-def aa_spi_slave_disable (aardvark):
-    """usage: int return = aa_spi_slave_disable(Aardvark aardvark)"""
+def aa_spi_subordinate_disable (aardvark):
+    """usage: int return = aa_spi_subordinate_disable(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_spi_slave_disable(aardvark)
+    return api.py_aa_spi_subordinate_disable(aardvark)
 
 
-# Set the slave response in the event the Aardvark is put
-# into slave mode and contacted by a Master.
-def aa_spi_slave_set_response (aardvark, data_out):
-    """usage: int return = aa_spi_slave_set_response(Aardvark aardvark, u08[] data_out)
+# Set the subordinate response in the event the Aardvark is put
+# into subordinate mode and contacted by a Main.
+def aa_spi_subordinate_set_response (aardvark, data_out):
+    """usage: int return = aa_spi_subordinate_set_response(Aardvark aardvark, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -1043,12 +1043,12 @@ def aa_spi_slave_set_response (aardvark, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_spi_slave_set_response(aardvark, num_bytes, data_out)
+    return api.py_aa_spi_subordinate_set_response(aardvark, num_bytes, data_out)
 
 
-# Read the bytes from an SPI slave reception
-def aa_spi_slave_read (aardvark, data_in):
-    """usage: (int return, u08[] data_in) = aa_spi_slave_read(Aardvark aardvark, u08[] data_in)
+# Read the bytes from an SPI subordinate reception
+def aa_spi_subordinate_read (aardvark, data_in):
+    """usage: (int return, u08[] data_in) = aa_spi_subordinate_read(Aardvark aardvark, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -1074,7 +1074,7 @@ def aa_spi_slave_read (aardvark, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_) = api.py_aa_spi_slave_read(aardvark, num_bytes, data_in)
+    (_ret_) = api.py_aa_spi_subordinate_read(aardvark, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(_ret_, len(data_in))):]
     return (_ret_, data_in)
@@ -1082,19 +1082,19 @@ def aa_spi_slave_read (aardvark, data_in):
 
 # Change the output polarity on the SS line.
 #
-# Note: When configured as an SPI slave, the Aardvark will
+# Note: When configured as an SPI subordinate, the Aardvark will
 # always be setup with SS as active low.  Hence this function
-# only affects the SPI master functions on the Aardvark.
+# only affects the SPI main functions on the Aardvark.
 # enum AardvarkSpiSSPolarity
 AA_SPI_SS_ACTIVE_LOW  = 0
 AA_SPI_SS_ACTIVE_HIGH = 1
 
-def aa_spi_master_ss_polarity (aardvark, polarity):
-    """usage: int return = aa_spi_master_ss_polarity(Aardvark aardvark, AardvarkSpiSSPolarity polarity)"""
+def aa_spi_main_ss_polarity (aardvark, polarity):
+    """usage: int return = aa_spi_main_ss_polarity(Aardvark aardvark, AardvarkSpiSSPolarity polarity)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_spi_master_ss_polarity(aardvark, polarity)
+    return api.py_aa_spi_main_ss_polarity(aardvark, polarity)
 
 
 

--- a/TestCode/aardvark_py.py
+++ b/TestCode/aardvark_py.py
@@ -544,9 +544,9 @@ AA_I2C_NO_STOP           = 0x04
 AA_I2C_SIZED_READ        = 0x10
 AA_I2C_SIZED_READ_EXTRA1 = 0x20
 
-# Read a stream of bytes from the I2C slave device.
-def aa_i2c_read (aardvark, slave_addr, flags, data_in):
-    """usage: (int return, u08[] data_in) = aa_i2c_read(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_in)
+# Read a stream of bytes from the I2C subordinate device.
+def aa_i2c_read (aardvark, subordinate_addr, flags, data_in):
+    """usage: (int return, u08[] data_in) = aa_i2c_read(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -572,7 +572,7 @@ def aa_i2c_read (aardvark, slave_addr, flags, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_) = api.py_aa_i2c_read(aardvark, slave_addr, flags, num_bytes, data_in)
+    (_ret_) = api.py_aa_i2c_read(aardvark, subordinate_addr, flags, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(_ret_, len(data_in))):]
     return (_ret_, data_in)
@@ -588,12 +588,12 @@ AA_I2C_STATUS_ARB_LOST      = 5
 AA_I2C_STATUS_BUS_LOCKED    = 6
 AA_I2C_STATUS_LAST_DATA_ACK = 7
 
-# Read a stream of bytes from the I2C slave device.
+# Read a stream of bytes from the I2C subordinate device.
 # This API function returns the number of bytes read into
 # the num_read variable.  The return value of the function
 # is a status code.
-def aa_i2c_read_ext (aardvark, slave_addr, flags, data_in):
-    """usage: (int return, u08[] data_in, u16 num_read) = aa_i2c_read_ext(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_in)
+def aa_i2c_read_ext (aardvark, subordinate_addr, flags, data_in):
+    """usage: (int return, u08[] data_in, u16 num_read) = aa_i2c_read_ext(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -619,15 +619,15 @@ def aa_i2c_read_ext (aardvark, slave_addr, flags, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_, num_read) = api.py_aa_i2c_read_ext(aardvark, slave_addr, flags, num_bytes, data_in)
+    (_ret_, num_read) = api.py_aa_i2c_read_ext(aardvark, subordinate_addr, flags, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(num_read, len(data_in))):]
     return (_ret_, data_in, num_read)
 
 
-# Write a stream of bytes to the I2C slave device.
-def aa_i2c_write (aardvark, slave_addr, flags, data_out):
-    """usage: int return = aa_i2c_write(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_out)
+# Write a stream of bytes to the I2C subordinate device.
+def aa_i2c_write (aardvark, subordinate_addr, flags, data_out):
+    """usage: int return = aa_i2c_write(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -643,15 +643,15 @@ def aa_i2c_write (aardvark, slave_addr, flags, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_i2c_write(aardvark, slave_addr, flags, num_bytes, data_out)
+    return api.py_aa_i2c_write(aardvark, subordinate_addr, flags, num_bytes, data_out)
 
 
-# Write a stream of bytes to the I2C slave device.
+# Write a stream of bytes to the I2C subordinate device.
 # This API function returns the number of bytes written into
 # the num_written variable.  The return value of the function
 # is a status code.
-def aa_i2c_write_ext (aardvark, slave_addr, flags, data_out):
-    """usage: (int return, u16 num_written) = aa_i2c_write_ext(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] data_out)
+def aa_i2c_write_ext (aardvark, subordinate_addr, flags, data_out):
+    """usage: (int return, u16 num_written) = aa_i2c_write_ext(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -667,18 +667,18 @@ def aa_i2c_write_ext (aardvark, slave_addr, flags, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_i2c_write_ext(aardvark, slave_addr, flags, num_bytes, data_out)
+    return api.py_aa_i2c_write_ext(aardvark, subordinate_addr, flags, num_bytes, data_out)
 
 
-# Do an atomic write+read to an I2C slave device by first
-# writing a stream of bytes to the I2C slave device and then
-# reading a stream of bytes back from the same slave device.
+# Do an atomic write+read to an I2C subordinate device by first
+# writing a stream of bytes to the I2C subordinate device and then
+# reading a stream of bytes back from the same subordinate device.
 # This API function returns the number of bytes written into
 # the num_written variable and the number of bytes read into
 # the num_read variable.  The return value of the function is
 # the status given as (read_status << 8) | (write_status).
-def aa_i2c_write_read (aardvark, slave_addr, flags, out_data, in_data):
-    """usage: (int return, u16 num_written, u08[] in_data, u16 num_read) = aa_i2c_write_read(Aardvark aardvark, u16 slave_addr, AardvarkI2cFlags flags, u08[] out_data, u08[] in_data)
+def aa_i2c_write_read (aardvark, subordinate_addr, flags, out_data, in_data):
+    """usage: (int return, u16 num_written, u08[] in_data, u16 num_read) = aa_i2c_write_read(Aardvark aardvark, u16 subordinate_addr, AardvarkI2cFlags flags, u08[] out_data, u08[] in_data)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -708,33 +708,33 @@ def aa_i2c_write_read (aardvark, slave_addr, flags, out_data, in_data):
         if in_data.typecode != 'B':
             raise TypeError("type for 'in_data' must be array('B')")
     # Call API function
-    (_ret_, num_written, num_read) = api.py_aa_i2c_write_read(aardvark, slave_addr, flags, out_num_bytes, out_data, in_num_bytes, in_data)
+    (_ret_, num_written, num_read) = api.py_aa_i2c_write_read(aardvark, subordinate_addr, flags, out_num_bytes, out_data, in_num_bytes, in_data)
     # in_data post-processing
     if __in_data: del in_data[max(0, min(num_read, len(in_data))):]
     return (_ret_, num_written, in_data, num_read)
 
 
-# Enable/Disable the Aardvark as an I2C slave device
-def aa_i2c_slave_enable (aardvark, addr, maxTxBytes, maxRxBytes):
-    """usage: int return = aa_i2c_slave_enable(Aardvark aardvark, u08 addr, u16 maxTxBytes, u16 maxRxBytes)"""
+# Enable/Disable the Aardvark as an I2C subordinate device
+def aa_i2c_subordinate_enable (aardvark, addr, maxTxBytes, maxRxBytes):
+    """usage: int return = aa_i2c_subordinate_enable(Aardvark aardvark, u08 addr, u16 maxTxBytes, u16 maxRxBytes)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_enable(aardvark, addr, maxTxBytes, maxRxBytes)
+    return api.py_aa_i2c_subordinate_enable(aardvark, addr, maxTxBytes, maxRxBytes)
 
 
-def aa_i2c_slave_disable (aardvark):
-    """usage: int return = aa_i2c_slave_disable(Aardvark aardvark)"""
+def aa_i2c_subordinate_disable (aardvark):
+    """usage: int return = aa_i2c_subordinate_disable(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_disable(aardvark)
+    return api.py_aa_i2c_subordinate_disable(aardvark)
 
 
-# Set the slave response in the event the Aardvark is put
-# into slave mode and contacted by a Master.
-def aa_i2c_slave_set_response (aardvark, data_out):
-    """usage: int return = aa_i2c_slave_set_response(Aardvark aardvark, u08[] data_out)
+# Set the subordinate response in the event the Aardvark is put
+# into subordinate mode and contacted by a Main.
+def aa_i2c_subordinate_set_response (aardvark, data_out):
+    """usage: int return = aa_i2c_subordinate_set_response(Aardvark aardvark, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -750,25 +750,25 @@ def aa_i2c_slave_set_response (aardvark, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_i2c_slave_set_response(aardvark, num_bytes, data_out)
+    return api.py_aa_i2c_subordinate_set_response(aardvark, num_bytes, data_out)
 
 
 # Return number of bytes written from a previous
-# Aardvark->I2C_master transmission.  Since the transmission is
+# Aardvark->I2C_main transmission.  Since the transmission is
 # happening asynchronously with respect to the PC host
 # software, there could be responses queued up from many
 # previous write transactions.
-def aa_i2c_slave_write_stats (aardvark):
-    """usage: int return = aa_i2c_slave_write_stats(Aardvark aardvark)"""
+def aa_i2c_subordinate_write_stats (aardvark):
+    """usage: int return = aa_i2c_subordinate_write_stats(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_write_stats(aardvark)
+    return api.py_aa_i2c_subordinate_write_stats(aardvark)
 
 
-# Read the bytes from an I2C slave reception
-def aa_i2c_slave_read (aardvark, data_in):
-    """usage: (int return, u08 addr, u08[] data_in) = aa_i2c_slave_read(Aardvark aardvark, u08[] data_in)
+# Read the bytes from an I2C subordinate reception
+def aa_i2c_subordinate_read (aardvark, data_in):
+    """usage: (int return, u08 addr, u08[] data_in) = aa_i2c_subordinate_read(Aardvark aardvark, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -794,23 +794,23 @@ def aa_i2c_slave_read (aardvark, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_, addr) = api.py_aa_i2c_slave_read(aardvark, num_bytes, data_in)
+    (_ret_, addr) = api.py_aa_i2c_subordinate_read(aardvark, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(_ret_, len(data_in))):]
     return (_ret_, addr, data_in)
 
 
 # Extended functions that return status code
-def aa_i2c_slave_write_stats_ext (aardvark):
-    """usage: (int return, u16 num_written) = aa_i2c_slave_write_stats_ext(Aardvark aardvark)"""
+def aa_i2c_subordinate_write_stats_ext (aardvark):
+    """usage: (int return, u16 num_written) = aa_i2c_subordinate_write_stats_ext(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_i2c_slave_write_stats_ext(aardvark)
+    return api.py_aa_i2c_subordinate_write_stats_ext(aardvark)
 
 
-def aa_i2c_slave_read_ext (aardvark, data_in):
-    """usage: (int return, u08 addr, u08[] data_in, u16 num_read) = aa_i2c_slave_read_ext(Aardvark aardvark, u08[] data_in)
+def aa_i2c_subordinate_read_ext (aardvark, data_in):
+    """usage: (int return, u08 addr, u08[] data_in, u16 num_read) = aa_i2c_subordinate_read_ext(Aardvark aardvark, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -836,7 +836,7 @@ def aa_i2c_slave_read_ext (aardvark, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_, addr, num_read) = api.py_aa_i2c_slave_read_ext(aardvark, num_bytes, data_in)
+    (_ret_, addr, num_read) = api.py_aa_i2c_subordinate_read_ext(aardvark, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(num_read, len(data_in))):]
     return (_ret_, addr, data_in, num_read)
@@ -960,7 +960,7 @@ AA_SPI_PHASE_SETUP_SAMPLE = 1
 AA_SPI_BITORDER_MSB = 0
 AA_SPI_BITORDER_LSB = 1
 
-# Configure the SPI master or slave interface
+# Configure the SPI main or subordinate interface
 def aa_spi_configure (aardvark, polarity, phase, bitorder):
     """usage: int return = aa_spi_configure(Aardvark aardvark, AardvarkSpiPolarity polarity, AardvarkSpiPhase phase, AardvarkSpiBitorder bitorder)"""
 
@@ -969,7 +969,7 @@ def aa_spi_configure (aardvark, polarity, phase, bitorder):
     return api.py_aa_spi_configure(aardvark, polarity, phase, bitorder)
 
 
-# Write a stream of bytes to the downstream SPI slave device.
+# Write a stream of bytes to the downstream SPI subordinate device.
 def aa_spi_write (aardvark, data_out, data_in):
     """usage: (int return, u08[] data_in) = aa_spi_write(Aardvark aardvark, u08[] data_out, u08[] data_in)
 
@@ -1007,27 +1007,27 @@ def aa_spi_write (aardvark, data_out, data_in):
     return (_ret_, data_in)
 
 
-# Enable/Disable the Aardvark as an SPI slave device
-def aa_spi_slave_enable (aardvark):
-    """usage: int return = aa_spi_slave_enable(Aardvark aardvark)"""
+# Enable/Disable the Aardvark as an SPI subordinate device
+def aa_spi_subordinate_enable (aardvark):
+    """usage: int return = aa_spi_subordinate_enable(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_spi_slave_enable(aardvark)
+    return api.py_aa_spi_subordinate_enable(aardvark)
 
 
-def aa_spi_slave_disable (aardvark):
-    """usage: int return = aa_spi_slave_disable(Aardvark aardvark)"""
+def aa_spi_subordinate_disable (aardvark):
+    """usage: int return = aa_spi_subordinate_disable(Aardvark aardvark)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_spi_slave_disable(aardvark)
+    return api.py_aa_spi_subordinate_disable(aardvark)
 
 
-# Set the slave response in the event the Aardvark is put
-# into slave mode and contacted by a Master.
-def aa_spi_slave_set_response (aardvark, data_out):
-    """usage: int return = aa_spi_slave_set_response(Aardvark aardvark, u08[] data_out)
+# Set the subordinate response in the event the Aardvark is put
+# into subordinate mode and contacted by a Main.
+def aa_spi_subordinate_set_response (aardvark, data_out):
+    """usage: int return = aa_spi_subordinate_set_response(Aardvark aardvark, u08[] data_out)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -1043,12 +1043,12 @@ def aa_spi_slave_set_response (aardvark, data_out):
     if data_out.typecode != 'B':
         raise TypeError("type for 'data_out' must be array('B')")
     # Call API function
-    return api.py_aa_spi_slave_set_response(aardvark, num_bytes, data_out)
+    return api.py_aa_spi_subordinate_set_response(aardvark, num_bytes, data_out)
 
 
-# Read the bytes from an SPI slave reception
-def aa_spi_slave_read (aardvark, data_in):
-    """usage: (int return, u08[] data_in) = aa_spi_slave_read(Aardvark aardvark, u08[] data_in)
+# Read the bytes from an SPI subordinate reception
+def aa_spi_subordinate_read (aardvark, data_in):
+    """usage: (int return, u08[] data_in) = aa_spi_subordinate_read(Aardvark aardvark, u08[] data_in)
 
     All arrays can be passed into the API as an ArrayType object or as
     a tuple (array, length), where array is an ArrayType object and
@@ -1074,7 +1074,7 @@ def aa_spi_slave_read (aardvark, data_in):
         if data_in.typecode != 'B':
             raise TypeError("type for 'data_in' must be array('B')")
     # Call API function
-    (_ret_) = api.py_aa_spi_slave_read(aardvark, num_bytes, data_in)
+    (_ret_) = api.py_aa_spi_subordinate_read(aardvark, num_bytes, data_in)
     # data_in post-processing
     if __data_in: del data_in[max(0, min(_ret_, len(data_in))):]
     return (_ret_, data_in)
@@ -1082,19 +1082,19 @@ def aa_spi_slave_read (aardvark, data_in):
 
 # Change the output polarity on the SS line.
 #
-# Note: When configured as an SPI slave, the Aardvark will
+# Note: When configured as an SPI subordinate, the Aardvark will
 # always be setup with SS as active low.  Hence this function
-# only affects the SPI master functions on the Aardvark.
+# only affects the SPI main functions on the Aardvark.
 # enum AardvarkSpiSSPolarity
 AA_SPI_SS_ACTIVE_LOW  = 0
 AA_SPI_SS_ACTIVE_HIGH = 1
 
-def aa_spi_master_ss_polarity (aardvark, polarity):
-    """usage: int return = aa_spi_master_ss_polarity(Aardvark aardvark, AardvarkSpiSSPolarity polarity)"""
+def aa_spi_main_ss_polarity (aardvark, polarity):
+    """usage: int return = aa_spi_main_ss_polarity(Aardvark aardvark, AardvarkSpiSSPolarity polarity)"""
 
     if not AA_LIBRARY_LOADED: return AA_INCOMPATIBLE_LIBRARY
     # Call API function
-    return api.py_aa_spi_master_ss_polarity(aardvark, polarity)
+    return api.py_aa_spi_main_ss_polarity(aardvark, polarity)
 
 
 

--- a/TestCode/archive/minimalmodbus.py
+++ b/TestCode/archive/minimalmodbus.py
@@ -68,15 +68,15 @@ CLOSE_PORT_AFTER_EACH_CALL = True
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU protocol (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU protocol (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``/com3`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
 
     """
 
-    def __init__(self, port, slaveaddress):
+    def __init__(self, port, subordinateaddress):
 
         self.serial = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, \
             stopbits=STOPBITS, timeout=TIMEOUT)
@@ -97,8 +97,8 @@ class Instrument():
                 - Defaults to :data:`TIMEOUT`.
         """
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.debug = False
         """Set this to :const:`True` to print the communication details. Defaults to :const:`False`."""
@@ -123,14 +123,14 @@ class Instrument():
 
 
     ########################################
-    ## Functions for talking to the slave ##
+    ## Functions for talking to the subordinate ##
     ########################################
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -145,10 +145,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -165,17 +165,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -190,7 +190,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -210,21 +210,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -248,17 +248,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -277,9 +277,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -287,8 +287,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -307,9 +307,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -320,12 +320,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -344,17 +344,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -371,13 +371,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -395,16 +395,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -424,12 +424,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -450,17 +450,17 @@ class Instrument():
 
 
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -497,9 +497,9 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value. Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value. Same functionality also
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -597,25 +597,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -637,37 +637,37 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
         ## Communicate ##
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode == 16:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -675,7 +675,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -703,15 +703,15 @@ class Instrument():
     ## Communication implementation details ##
     ##########################################
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -720,23 +720,23 @@ class Instrument():
 
         """
         _checkFunctioncode(functioncode, None )
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
-        message             = _embedPayload(self.address, functioncode, payloadToSlave)
+        message             = _embedPayload(self.address, functioncode, payloadToSubordinate)
         response            = self._communicate(message)
-        payloadFromSlave    = _extractPayload(response, self.address, functioncode)
+        payloadFromSubordinate    = _extractPayload(response, self.address, functioncode)
 
-        return payloadFromSlave
+        return payloadFromSubordinate
 
 
     def _communicate(self, message):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            message (str): The raw message that is to be sent to the slave.
+            message (str): The raw message that is to be sent to the subordinate.
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -766,10 +766,10 @@ class Instrument():
             Note that these strings can look pretty strange when printed, as values 0 to 31 (dec) are
             ASCII control signs. For example 'vertical tab' and 'line feed' are among those.
 
-            The **raw message** to the slave has the frame format: slaveaddress byte + functioncode byte +
+            The **raw message** to the subordinate has the frame format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes).
 
-            The **received message** should have the format: slaveaddress byte + functioncode byte +
+            The **received message** should have the format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes)
 
             For Python3, the information sent to and from pySerial should be of the type bytes.
@@ -811,41 +811,41 @@ class Instrument():
 # Payload handling #
 ####################
 
-def _embedPayload(slaveaddress, functioncode, payloaddata):
-    """Build a message from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, functioncode, payloaddata):
+    """Build a message from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) message string for sending to the slave (including CRC etc).
+        The built (raw) message string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
-    The resulting message has the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+    The resulting message has the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
 
-    The CRC is calculated from the string made up of slaveaddress byte + functioncode byte + payloaddata.
+    The CRC is calculated from the string made up of subordinateaddress byte + functioncode byte + payloaddata.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
     # Build message
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
     message = firstPart + _calculateCrcString(firstPart)
     return message
 
 
-def _extractPayload(response, slaveaddress, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * functioncode (int): Used here for error checking only.
 
     Returns:
@@ -854,7 +854,7 @@ def _extractPayload(response, slaveaddress, functioncode):
     Raises:
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
-    The received message should have the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+    The received message should have the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
 
     """
     BYTEPOSITION_FOR_SLAVEADDRESS          = 0  # Zero-based counting
@@ -865,7 +865,7 @@ def _extractPayload(response, slaveaddress, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
 
     # Check CRC
@@ -879,18 +879,18 @@ def _extractPayload(response, slaveaddress, functioncode):
             _twoByteStringToNum(calculatedCRC), calculatedCRC,
             response))
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord( response[BYTEPOSITION_FOR_SLAVEADDRESS] )
 
-    if responseaddress != slaveaddress:
-        raise ValueError( 'Wrong return slave address: {0} instead of {1}. The response is: {2!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError( 'Wrong return subordinate address: {0} instead of {1}. The response is: {2!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord( response[BYTEPOSITION_FOR_FUNCTIONCODE ] )
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {0!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {0!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {0} instead of {1}. The response is: {2!r}'.format( \
@@ -942,8 +942,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1036,7 +1036,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1068,7 +1068,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1098,11 +1098,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1143,7 +1143,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1182,14 +1182,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1211,13 +1211,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1281,7 +1281,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -1646,11 +1646,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -1659,7 +1659,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):

--- a/TestCode/canvass.py
+++ b/TestCode/canvass.py
@@ -5,7 +5,7 @@ from constants import DELAY,DB_PATH
 def update_data_for_cod_bod():
     conn = sqlite3.connect('ubiqx_db.db')
     c = conn.cursor()
-    execute_query = c.execute('''select cod,bod,tss from front_end_data where slave_id=1''')
+    execute_query = c.execute('''select cod,bod,tss from front_end_data where subordinate_id=1''')
     result_set = c.fetchall()
 
     data_for_cod = 0

--- a/TestCode/instrumentDrivers.py
+++ b/TestCode/instrumentDrivers.py
@@ -133,7 +133,7 @@ class pmHP8163:
         return float(self.inst.ask(cmd))
 
     def triggerReadPower(self):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.inst.write( ':INIT%d:CHAN1:TRIG:IMM' % self.slot)
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.slot, self.head)

--- a/TestCode/instrumentDriversJ.py
+++ b/TestCode/instrumentDriversJ.py
@@ -153,7 +153,7 @@ class pmHP8163:
         return float(self.inst.ask(cmd))
 
     def triggerReadPower(self):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.inst.write( ':INIT%d:CHAN1:TRIG:IMM' % self.slot)
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.slot, self.head)

--- a/TestCode/instrumentDriversNEW.py
+++ b/TestCode/instrumentDriversNEW.py
@@ -82,7 +82,7 @@ class pmHP8163:
         return float(self.inst.ask(cmd))
 
     def triggerReadPower(self):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.inst.write( ':INIT%d:CHAN1:TRIG:IMM' % self.slot)
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.slot, self.head)
@@ -502,7 +502,7 @@ class pmHP8156:
         return float(self.inst.ask(cmd))
 
     def triggerReadPower(self):
-        #trigger must be done on the master channel, number 1.  It will also affect slave channel.
+        #trigger must be done on the main channel, number 1.  It will also affect subordinate channel.
         #this is why the trigger is hard coded to be channel 1.
         self.inst.write( ':INIT%d:CHAN1:TRIG:IMM' % self.slot)
         strCmd = 'FETC%d:CHAN%d:POW?'%(self.slot, self.head)

--- a/TestCode/minimalmodbus.py
+++ b/TestCode/minimalmodbus.py
@@ -68,15 +68,15 @@ CLOSE_PORT_AFTER_EACH_CALL = True
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU protocol (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU protocol (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``/com3`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
 
     """
 
-    def __init__(self, port, slaveaddress):
+    def __init__(self, port, subordinateaddress):
 
         self.serial = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, \
             stopbits=STOPBITS, timeout=TIMEOUT)
@@ -97,8 +97,8 @@ class Instrument():
                 - Defaults to :data:`TIMEOUT`.
         """
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.debug = False
         """Set this to :const:`True` to print the communication details. Defaults to :const:`False`."""
@@ -123,14 +123,14 @@ class Instrument():
 
 
     ########################################
-    ## Functions for talking to the slave ##
+    ## Functions for talking to the subordinate ##
     ########################################
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -145,10 +145,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -165,17 +165,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -190,7 +190,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -210,21 +210,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -248,17 +248,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -277,9 +277,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -287,8 +287,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -307,9 +307,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -320,12 +320,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -344,17 +344,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -371,13 +371,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -395,16 +395,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -424,12 +424,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -450,17 +450,17 @@ class Instrument():
 
 
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -497,9 +497,9 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value. Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value. Same functionality also
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -597,25 +597,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -637,37 +637,37 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
         ## Communicate ##
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode == 16:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -675,7 +675,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -703,15 +703,15 @@ class Instrument():
     ## Communication implementation details ##
     ##########################################
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -720,23 +720,23 @@ class Instrument():
 
         """
         _checkFunctioncode(functioncode, None )
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
-        message             = _embedPayload(self.address, functioncode, payloadToSlave)
+        message             = _embedPayload(self.address, functioncode, payloadToSubordinate)
         response            = self._communicate(message)
-        payloadFromSlave    = _extractPayload(response, self.address, functioncode)
+        payloadFromSubordinate    = _extractPayload(response, self.address, functioncode)
 
-        return payloadFromSlave
+        return payloadFromSubordinate
 
 
     def _communicate(self, message):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            message (str): The raw message that is to be sent to the slave.
+            message (str): The raw message that is to be sent to the subordinate.
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -766,10 +766,10 @@ class Instrument():
             Note that these strings can look pretty strange when printed, as values 0 to 31 (dec) are
             ASCII control signs. For example 'vertical tab' and 'line feed' are among those.
 
-            The **raw message** to the slave has the frame format: slaveaddress byte + functioncode byte +
+            The **raw message** to the subordinate has the frame format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes).
 
-            The **received message** should have the format: slaveaddress byte + functioncode byte +
+            The **received message** should have the format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes)
 
             For Python3, the information sent to and from pySerial should be of the type bytes.
@@ -811,41 +811,41 @@ class Instrument():
 # Payload handling #
 ####################
 
-def _embedPayload(slaveaddress, functioncode, payloaddata):
-    """Build a message from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, functioncode, payloaddata):
+    """Build a message from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) message string for sending to the slave (including CRC etc).
+        The built (raw) message string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
-    The resulting message has the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+    The resulting message has the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
 
-    The CRC is calculated from the string made up of slaveaddress byte + functioncode byte + payloaddata.
+    The CRC is calculated from the string made up of subordinateaddress byte + functioncode byte + payloaddata.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
     # Build message
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
     message = firstPart + _calculateCrcString(firstPart)
     return message
 
 
-def _extractPayload(response, slaveaddress, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * functioncode (int): Used here for error checking only.
 
     Returns:
@@ -854,7 +854,7 @@ def _extractPayload(response, slaveaddress, functioncode):
     Raises:
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
-    The received message should have the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+    The received message should have the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
 
     """
     BYTEPOSITION_FOR_SLAVEADDRESS          = 0  # Zero-based counting
@@ -865,7 +865,7 @@ def _extractPayload(response, slaveaddress, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
 
     # Check CRC
@@ -879,18 +879,18 @@ def _extractPayload(response, slaveaddress, functioncode):
             _twoByteStringToNum(calculatedCRC), calculatedCRC,
             response))
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord( response[BYTEPOSITION_FOR_SLAVEADDRESS] )
 
-    if responseaddress != slaveaddress:
-        raise ValueError( 'Wrong return slave address: {0} instead of {1}. The response is: {2!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError( 'Wrong return subordinate address: {0} instead of {1}. The response is: {2!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord( response[BYTEPOSITION_FOR_FUNCTIONCODE ] )
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {0!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {0!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {0} instead of {1}. The response is: {2!r}'.format( \
@@ -942,8 +942,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1036,7 +1036,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1068,7 +1068,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1098,11 +1098,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1143,7 +1143,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1182,14 +1182,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1211,13 +1211,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1281,7 +1281,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -1646,11 +1646,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -1659,7 +1659,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.